### PR TITLE
Feat: 회고 관련 api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,12 +22,18 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	//jpa
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	//oauth2
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	//lombok
 	compileOnly 'org.projectlombok:lombok'
+	//h2
 	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
+	// mysql
+	implementation 'mysql:mysql-connector-java:8.0.32'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/floud/demo/FloudApplication.java
+++ b/src/main/java/floud/demo/FloudApplication.java
@@ -2,8 +2,10 @@ package floud.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class FloudApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/floud/demo/common/Error.java
+++ b/src/main/java/floud/demo/common/Error.java
@@ -1,0 +1,25 @@
+package floud.demo.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Error {
+    // Default
+    ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
+
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/floud/demo/common/Success.java
+++ b/src/main/java/floud/demo/common/Success.java
@@ -1,0 +1,23 @@
+package floud.demo.common;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Success {
+    // Default
+    SUCCESS(HttpStatus.OK, "Request successfully processed"),
+
+    ;
+
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/floud/demo/common/domain/BaseTimeEntity.java
+++ b/src/main/java/floud/demo/common/domain/BaseTimeEntity.java
@@ -1,0 +1,21 @@
+package floud.demo.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    LocalDateTime created_at;
+
+    @LastModifiedDate
+    LocalDateTime updated_at;
+}

--- a/src/main/java/floud/demo/common/exception/ApiException.java
+++ b/src/main/java/floud/demo/common/exception/ApiException.java
@@ -4,7 +4,13 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 public abstract class ApiException extends ResponseStatusException {
-    public ApiException(final String message, final HttpStatus status) {
-        super(status, message);
+    private final boolean success;
+    public ApiException(final HttpStatus code, final String message) {
+        super(code, message);
+        this.success = false;
+    }
+
+    public boolean isSuccess() {
+        return success;
     }
 }

--- a/src/main/java/floud/demo/common/exception/ApiException.java
+++ b/src/main/java/floud/demo/common/exception/ApiException.java
@@ -1,0 +1,10 @@
+package floud.demo.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+public abstract class ApiException extends ResponseStatusException {
+    public ApiException(final String message, final HttpStatus status) {
+        super(status, message);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/ConflictException.java
+++ b/src/main/java/floud/demo/common/exception/ConflictException.java
@@ -7,6 +7,6 @@ import static org.springframework.http.HttpStatus.CONFLICT;
 @ResponseStatus(CONFLICT)
 public abstract class ConflictException extends ApiException {
     public ConflictException(final String message) {
-        super(message, CONFLICT);
+        super(CONFLICT, message);
     }
 }

--- a/src/main/java/floud/demo/common/exception/ConflictException.java
+++ b/src/main/java/floud/demo/common/exception/ConflictException.java
@@ -1,0 +1,12 @@
+package floud.demo.common.exception;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+
+@ResponseStatus(CONFLICT)
+public abstract class ConflictException extends ApiException {
+    public ConflictException(final String message) {
+        super(message, CONFLICT);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/ForbiddenException.java
+++ b/src/main/java/floud/demo/common/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package floud.demo.common.exception;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+@ResponseStatus(FORBIDDEN)
+public abstract class ForbiddenException extends ApiException {
+    public ForbiddenException(final String message) {
+        super(message, FORBIDDEN);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/ForbiddenException.java
+++ b/src/main/java/floud/demo/common/exception/ForbiddenException.java
@@ -7,6 +7,6 @@ import static org.springframework.http.HttpStatus.FORBIDDEN;
 @ResponseStatus(FORBIDDEN)
 public abstract class ForbiddenException extends ApiException {
     public ForbiddenException(final String message) {
-        super(message, FORBIDDEN);
+        super(FORBIDDEN, message);
     }
 }

--- a/src/main/java/floud/demo/common/exception/InternalServerErrorException.java
+++ b/src/main/java/floud/demo/common/exception/InternalServerErrorException.java
@@ -7,6 +7,6 @@ import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 @ResponseStatus(INTERNAL_SERVER_ERROR)
 public abstract class InternalServerErrorException extends ApiException{
     public InternalServerErrorException (final String message) {
-        super(message, INTERNAL_SERVER_ERROR);
+        super(INTERNAL_SERVER_ERROR, message);
     }
 }

--- a/src/main/java/floud/demo/common/exception/InternalServerErrorException.java
+++ b/src/main/java/floud/demo/common/exception/InternalServerErrorException.java
@@ -1,0 +1,12 @@
+package floud.demo.common.exception;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@ResponseStatus(INTERNAL_SERVER_ERROR)
+public abstract class InternalServerErrorException extends ApiException{
+    public InternalServerErrorException (final String message) {
+        super(message, INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/NotFoundException.java
+++ b/src/main/java/floud/demo/common/exception/NotFoundException.java
@@ -7,6 +7,6 @@ import static org.springframework.http.HttpStatus.NOT_FOUND;
 @ResponseStatus(NOT_FOUND)
 public abstract class NotFoundException extends ApiException {
     public NotFoundException(final String message) {
-        super(message, NOT_FOUND);
+        super(NOT_FOUND, message);
     }
 }

--- a/src/main/java/floud/demo/common/exception/NotFoundException.java
+++ b/src/main/java/floud/demo/common/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package floud.demo.common.exception;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@ResponseStatus(NOT_FOUND)
+public abstract class NotFoundException extends ApiException {
+    public NotFoundException(final String message) {
+        super(message, NOT_FOUND);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/UnauthorizedException.java
+++ b/src/main/java/floud/demo/common/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package floud.demo.common.exception;
+
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+
+@ResponseStatus(UNAUTHORIZED)
+public abstract class UnauthorizedException extends ApiException {
+    public UnauthorizedException(final String message) {
+        super(message, UNAUTHORIZED);
+    }
+}

--- a/src/main/java/floud/demo/common/exception/UnauthorizedException.java
+++ b/src/main/java/floud/demo/common/exception/UnauthorizedException.java
@@ -7,6 +7,6 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @ResponseStatus(UNAUTHORIZED)
 public abstract class UnauthorizedException extends ApiException {
     public UnauthorizedException(final String message) {
-        super(message, UNAUTHORIZED);
+        super(UNAUTHORIZED, message);
     }
 }

--- a/src/main/java/floud/demo/common/response/ApiResponse.java
+++ b/src/main/java/floud/demo/common/response/ApiResponse.java
@@ -1,0 +1,49 @@
+package floud.demo.common.response;
+
+import floud.demo.common.Success;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String message;
+    private final T data;
+
+    public static <T> ApiResponse<T> success() {
+        return new ApiResponse<>(
+                Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> success(Success success) {
+        return new ApiResponse<>(
+                success.getHttpStatusCode(),
+                success.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> success(Success success, T data) {
+        return new ApiResponse<>(
+                success.getHttpStatusCode(),
+                success.getMessage(),
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(
+                Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getMessage(),
+                data
+        );
+    }
+
+}

--- a/src/main/java/floud/demo/common/response/ApiResponse.java
+++ b/src/main/java/floud/demo/common/response/ApiResponse.java
@@ -13,12 +13,14 @@ import lombok.ToString;
 public class ApiResponse<T> {
 
     private final int code;
+    private final boolean success;
     private final String message;
     private final T data;
 
     public static <T> ApiResponse<T> success() {
         return new ApiResponse<>(
                 Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getHttpStatus().is2xxSuccessful(),
                 Success.SUCCESS.getMessage(),
                 null
         );
@@ -27,6 +29,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(Success success) {
         return new ApiResponse<>(
                 success.getHttpStatusCode(),
+                success.getHttpStatus().is2xxSuccessful(),
                 success.getMessage(),
                 null
         );
@@ -35,6 +38,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(Success success, T data) {
         return new ApiResponse<>(
                 success.getHttpStatusCode(),
+                success.getHttpStatus().is2xxSuccessful(),
                 success.getMessage(),
                 data
         );
@@ -43,6 +47,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> success(T data) {
         return new ApiResponse<>(
                 Success.SUCCESS.getHttpStatusCode(),
+                Success.SUCCESS.getHttpStatus().is2xxSuccessful(),
                 Success.SUCCESS.getMessage(),
                 data
         );
@@ -52,6 +57,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> failure(Error error) {
         return new ApiResponse<>(
                 error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
                 error.getMessage(),
                 null
         );
@@ -60,6 +66,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> failure(Error error, String message) {
         return new ApiResponse<>(
                 error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
                 message,
                 null
         );
@@ -68,6 +75,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> failure(Error error, T data) {
         return new ApiResponse<>(
                 error.getHttpStatusCode(),
+                error.getHttpStatus().is2xxSuccessful(),
                 error.getMessage(),
                 data
         );
@@ -76,6 +84,7 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> failure(T data) {
         return new ApiResponse<>(
                 Error.ERROR.getHttpStatusCode(),
+                Error.ERROR.getHttpStatus().is2xxSuccessful(),
                 Error.ERROR.getMessage(),
                 data
         );

--- a/src/main/java/floud/demo/common/response/ApiResponse.java
+++ b/src/main/java/floud/demo/common/response/ApiResponse.java
@@ -1,8 +1,5 @@
 package floud.demo.common.response;
 
-import floud.demo.common.Success;
-import floud.demo.common.Error;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/floud/demo/common/response/ApiResponse.java
+++ b/src/main/java/floud/demo/common/response/ApiResponse.java
@@ -1,6 +1,8 @@
 package floud.demo.common.response;
 
 import floud.demo.common.Success;
+import floud.demo.common.Error;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -42,6 +44,39 @@ public class ApiResponse<T> {
         return new ApiResponse<>(
                 Success.SUCCESS.getHttpStatusCode(),
                 Success.SUCCESS.getMessage(),
+                data
+        );
+    }
+
+
+    public static <T> ApiResponse<T> failure(Error error) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                error.getMessage(),
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(Error error, String message) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                message,
+                null
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(Error error, T data) {
+        return new ApiResponse<>(
+                error.getHttpStatusCode(),
+                error.getMessage(),
+                data
+        );
+    }
+
+    public static <T> ApiResponse<T> failure(T data) {
+        return new ApiResponse<>(
+                Error.ERROR.getHttpStatusCode(),
+                Error.ERROR.getMessage(),
                 data
         );
     }

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -1,4 +1,4 @@
-package floud.demo.common;
+package floud.demo.common.response;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -7,12 +7,14 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum Success {
+public enum Error {
     // Default
-    SUCCESS(HttpStatus.OK, "Request successfully processed"),
+    ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
 
+
+    // 500 INTERNAL SERVER ERROR
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     ;
-
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -13,6 +13,7 @@ public enum Error {
 
     // 404 NOT FOUND
     USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
+    MEMOIR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회고를 찾을 수 없습니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -11,6 +11,8 @@ public enum Error {
     // Default
     ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
 
+    // 404 NOT FOUND
+    USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -15,6 +15,9 @@ public enum Error {
     USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     MEMOIR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회고를 찾을 수 없습니다."),
 
+    // 409 CONFLICT
+    MEMOIR_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 오늘의 회고를 작성하였습니다."),
+
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     ;

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -14,7 +14,7 @@ public enum Success {
     //200 SUCCESS
     MEMOIR_UPDATE_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
     ONE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "하나의 회고를 성공적으로 조회하였습니다."),
-    MULTIPLE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "이번 주 회고 목록을 성공적으로 조회하였습니다."),
+    MULTIPLE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "주차별 회고 목록을 성공적으로 조회하였습니다."),
 
     //201 CREATED SUCCESS
     MEMOIR_CREATE_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -11,6 +11,8 @@ public enum Success {
     // Default
     SUCCESS(HttpStatus.OK, "Request successfully processed"),
 
+    //201 CREATED SUCCESS
+    MEMOIR_CREATE_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     ;
 
 

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -12,13 +12,19 @@ public enum Success {
     SUCCESS(HttpStatus.OK, "Request successfully processed"),
 
     //200 SUCCESS
-    MEMOIR_UPDATE_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
+    UPDATE_MEMOIR_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
     GET_MY_MEMOIR_SUCCESS(HttpStatus.OK , "나의 회고를 성공적으로 조회하였습니다."),
     GET_FRIEND_MEMOIR_SUCCESS(HttpStatus.OK , "친구의 회고를 성공적으로 조회하였습니다."),
-    MULTIPLE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "주차별 회고 목록을 성공적으로 조회하였습니다."),
+    GET_MULTIPLE_MEMOIR_SUCCESS(HttpStatus.OK , "주차별 회고 목록을 성공적으로 조회하였습니다."),
+
+    GET_MYPAGE_SUCCESS(HttpStatus.OK , "마이페이지를 성공적으로 조회하였습니다."),
+    GET_MYPAGE_COMMUNITY_SUCCESS(HttpStatus.OK , "내가 쓴 글을 성공적으로 조회하였습니다."),
+    REJECT_MY_FRIEND_SUCCESS(HttpStatus.OK , "성공적으로 친구 관계를 삭제하였습니다."),
 
     //201 CREATED SUCCESS
-    MEMOIR_CREATE_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
+    CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
+    UPDATE_MYPAGE_SUCCESS(HttpStatus.CREATED , "마이페이지를 성공적으로 수정하였습니다."),
+    ACCEPT_MY_FRIEND_SUCCESS(HttpStatus.CREATED , "성공적으로 친구 수락을 완료하였습니다. "),
     ;
 
 

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -1,4 +1,4 @@
-package floud.demo.common;
+package floud.demo.common.response;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -7,14 +7,12 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public enum Error {
+public enum Success {
     // Default
-    ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
+    SUCCESS(HttpStatus.OK, "Request successfully processed"),
 
-
-    // 500 INTERNAL SERVER ERROR
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
     ;
+
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -11,6 +11,11 @@ public enum Success {
     // Default
     SUCCESS(HttpStatus.OK, "Request successfully processed"),
 
+    //200 SUCCESS
+    MEMOIR_UPDATE_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
+    ONE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "하나의 회고를 성공적으로 조회하였습니다."),
+    MULTIPLE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "이번 주 회고 목록을 성공적으로 조회하였습니다."),
+
     //201 CREATED SUCCESS
     MEMOIR_CREATE_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     ;

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -13,7 +13,8 @@ public enum Success {
 
     //200 SUCCESS
     MEMOIR_UPDATE_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
-    ONE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "하나의 회고를 성공적으로 조회하였습니다."),
+    GET_MY_MEMOIR_SUCCESS(HttpStatus.OK , "나의 회고를 성공적으로 조회하였습니다."),
+    GET_FRIEND_MEMOIR_SUCCESS(HttpStatus.OK , "친구의 회고를 성공적으로 조회하였습니다."),
     MULTIPLE_MEMOIR_GET_SUCCESS(HttpStatus.OK , "주차별 회고 목록을 성공적으로 조회하였습니다."),
 
     //201 CREATED SUCCESS

--- a/src/main/java/floud/demo/controller/FriendController.java
+++ b/src/main/java/floud/demo/controller/FriendController.java
@@ -1,0 +1,22 @@
+package floud.demo.controller;
+
+import floud.demo.common.response.ApiResponse;
+import floud.demo.service.FriendService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/friend")
+public class FriendController {
+    private final FriendService friendService;
+
+    @GetMapping("memoir/{memoir_id}")
+    public ApiResponse<?> getOneMemoir(@PathVariable Long memoir_id){
+        return friendService.getMemoirOfFriend(memoir_id);
+    }
+
+}

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -30,7 +30,7 @@ public class MemoirController {
     }
 
     @GetMapping("/week")
-    public ApiResponse<?> getThisWeekMemoir(@RequestParam(name = "start-date") LocalDateTime startDate){
-        return memoirService.getThisWeekMemoir(startDate);
+    public ApiResponse<?> getWeekMemoir(@RequestParam(name = "start-date") LocalDateTime startDate){
+        return memoirService.getWeekMemoir(startDate);
     }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -2,12 +2,10 @@ package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
 import floud.demo.dto.memoir.MemoirCreateRequestDto;
+import floud.demo.dto.memoir.MemoirUpdateRequestDto;
 import floud.demo.service.MemoirService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,5 +15,10 @@ public class MemoirController {
     @PostMapping
     public ApiResponse<?> createMemoir(@RequestBody MemoirCreateRequestDto memoirCreateRequestDto){
         return memoirService.createMemoir(memoirCreateRequestDto);
+    }
+
+    @PutMapping("/{memoir_id}")
+    public ApiResponse<?> updateMemoir(@PathVariable Long memoir_id, @RequestBody MemoirUpdateRequestDto memoirUpdateRequestDto){
+        return memoirService.updateMemoir(memoir_id, memoirUpdateRequestDto);
     }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -28,4 +28,9 @@ public class MemoirController {
     public ApiResponse<?> getOneMemoir(@PathVariable Long memoir_id){
         return memoirService.getOneMemoir(memoir_id);
     }
+
+    @GetMapping("/week")
+    public ApiResponse<?> getThisWeekMemoir(@RequestParam(name = "start-date") LocalDateTime startDate){
+        return memoirService.getThisWeekMemoir(startDate);
+    }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -7,7 +7,7 @@ import floud.demo.service.MemoirService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @RequiredArgsConstructor
 @RestController
@@ -25,13 +25,13 @@ public class MemoirController {
     }
 
     @GetMapping("/my")
-    public ApiResponse<?> getOneMemoir(@RequestParam(name = "date") LocalDateTime dateTime){
+    public ApiResponse<?> getOneMemoir(@RequestParam(name = "date") LocalDate dateTime){
         return memoirService.getOneMemoir(dateTime);
     }
 
     @GetMapping("/week")
-    public ApiResponse<?> getWeekMemoir(@RequestParam(name = "start-date") LocalDateTime startDate){
-        LocalDateTime endDate = startDate.plusDays(7);
+    public ApiResponse<?> getWeekMemoir(@RequestParam(name = "start-date") LocalDate startDate){
+        LocalDate endDate = startDate.plusDays(7);
         return memoirService.getWeekMemoir(startDate, endDate);
     }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -24,9 +24,9 @@ public class MemoirController {
         return memoirService.updateMemoir(memoir_id, memoirUpdateRequestDto);
     }
 
-    @GetMapping("/{memoir_id}")
-    public ApiResponse<?> getOneMemoir(@PathVariable Long memoir_id){
-        return memoirService.getOneMemoir(memoir_id);
+    @GetMapping("/my")
+    public ApiResponse<?> getOneMemoir(@RequestParam(name = "date") LocalDateTime dateTime){
+        return memoirService.getOneMemoir(dateTime);
     }
 
     @GetMapping("/week")

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/memoir")
 public class MemoirController {
-    final private MemoirService memoirService;
+    private final MemoirService memoirService;
     @PostMapping
     public ApiResponse<?> createMemoir(@RequestBody MemoirCreateRequestDto memoirCreateRequestDto){
         return memoirService.createMemoir(memoirCreateRequestDto);

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -1,0 +1,11 @@
+package floud.demo.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/memoir")
+public class MemoirController {
+}

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -7,6 +7,8 @@ import floud.demo.service.MemoirService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/memoir")
@@ -20,5 +22,10 @@ public class MemoirController {
     @PutMapping("/{memoir_id}")
     public ApiResponse<?> updateMemoir(@PathVariable Long memoir_id, @RequestBody MemoirUpdateRequestDto memoirUpdateRequestDto){
         return memoirService.updateMemoir(memoir_id, memoirUpdateRequestDto);
+    }
+
+    @GetMapping("/{memoir_id}")
+    public ApiResponse<?> getOneMemoir(@PathVariable Long memoir_id){
+        return memoirService.getOneMemoir(memoir_id);
     }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -31,6 +31,7 @@ public class MemoirController {
 
     @GetMapping("/week")
     public ApiResponse<?> getWeekMemoir(@RequestParam(name = "start-date") LocalDateTime startDate){
-        return memoirService.getWeekMemoir(startDate);
+        LocalDateTime endDate = startDate.plusDays(7);
+        return memoirService.getWeekMemoir(startDate, endDate);
     }
 }

--- a/src/main/java/floud/demo/controller/MemoirController.java
+++ b/src/main/java/floud/demo/controller/MemoirController.java
@@ -1,6 +1,11 @@
 package floud.demo.controller;
 
+import floud.demo.common.response.ApiResponse;
+import floud.demo.dto.memoir.MemoirCreateRequestDto;
+import floud.demo.service.MemoirService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,4 +13,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("api/memoir")
 public class MemoirController {
+    final private MemoirService memoirService;
+    @PostMapping
+    public ApiResponse<?> createMemoir(@RequestBody MemoirCreateRequestDto memoirCreateRequestDto){
+        return memoirService.createMemoir(memoirCreateRequestDto);
+    }
 }

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -1,0 +1,18 @@
+package floud.demo.controller;
+
+import floud.demo.common.response.ApiResponse;
+import floud.demo.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/mypage")
+public class MypageController {
+    private final MyPageService myPageService;
+    @GetMapping
+    public ApiResponse<?> getMypage(){
+        return myPageService.getMypage();
+    }
+}

--- a/src/main/java/floud/demo/domain/Goal.java
+++ b/src/main/java/floud/demo/domain/Goal.java
@@ -1,0 +1,34 @@
+package floud.demo.domain;
+
+import floud.demo.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Entity
+public class Goal extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "goal_id")
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime deadLine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private Users users;
+
+    @Builder
+    public Goal(Long id, String content, LocalDateTime deadLine){
+        this.id = id;
+        this.content = content;
+        this.deadLine = deadLine;
+    }
+}

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -4,11 +4,10 @@ import floud.demo.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
 @Entity
 public class Memoir extends BaseTimeEntity {
     @Id
@@ -31,4 +30,14 @@ public class Memoir extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private Users users;
+
+    @Builder
+    public Memoir(Long id, String title, String keep_memoir, String problem_memoir, String try_memoir, Users users){
+        this.id = id;
+        this.title = title;
+        this.keep_memoir = keep_memoir;
+        this.problem_memoir = problem_memoir;
+        this.try_memoir = try_memoir;
+        this.users = users;
+    }
 }

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -1,0 +1,34 @@
+package floud.demo.domain;
+
+import floud.demo.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Memoir extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memoir_id")
+    private Long id;
+
+    @Column
+    private String title;
+
+    @Column
+    private String keep_memoir;
+
+    @Column
+    private String problem_memoir;
+
+    @Column
+    private String try_memoir;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private Users users;
+}

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -2,12 +2,12 @@ package floud.demo.domain;
 
 import floud.demo.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @Entity
 public class Memoir extends BaseTimeEntity {
     @Id

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -1,16 +1,21 @@
 package floud.demo.domain;
 
-import floud.demo.common.domain.BaseTimeEntity;
 import floud.demo.dto.memoir.MemoirUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Memoir extends BaseTimeEntity {
+public class Memoir{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "memoir_id")
@@ -28,12 +33,22 @@ public class Memoir extends BaseTimeEntity {
     @Column
     private String try_memoir;
 
+    //YYYY-MM-DD 형식으로 변경
+    @CreatedDate
+    @Column
+    private LocalDate created_at;
+
+    @LastModifiedDate
+    @Column
+    private  LocalDate updated_at;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private Users users;
 
     @Builder
-    public Memoir(Long id, String title, String keep_memoir, String problem_memoir, String try_memoir, Users users){
+    public Memoir(Long id, String title, String keep_memoir, String problem_memoir, String try_memoir,
+                  LocalDate created_at, LocalDate updated_at, Users users){
         this.id = id;
         this.title = title;
         this.keep_memoir = keep_memoir;

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -40,4 +40,11 @@ public class Memoir extends BaseTimeEntity {
         this.try_memoir = try_memoir;
         this.users = users;
     }
+
+    public void update(String title, String keep_memoir, String problem_memoir, String try_memoir){
+        this.title = title;
+        this.keep_memoir = keep_memoir;
+        this.problem_memoir = problem_memoir;
+        this.try_memoir = try_memoir;
+    }
 }

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -1,6 +1,7 @@
 package floud.demo.domain;
 
 import floud.demo.common.domain.BaseTimeEntity;
+import floud.demo.dto.memoir.MemoirUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,10 +42,10 @@ public class Memoir extends BaseTimeEntity {
         this.users = users;
     }
 
-    public void update(String title, String keep_memoir, String problem_memoir, String try_memoir){
-        this.title = title;
-        this.keep_memoir = keep_memoir;
-        this.problem_memoir = problem_memoir;
-        this.try_memoir = try_memoir;
+    public void update(MemoirUpdateRequestDto updateRequestDto){
+        this.title = updateRequestDto.getTitle();
+        this.keep_memoir = updateRequestDto.getKeep_memoir();
+        this.problem_memoir = updateRequestDto.getProblem_memoir();
+        this.try_memoir = updateRequestDto.getTry_memoir();
     }
 }

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -12,9 +12,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+
 @Entity
 public class Users extends BaseTimeEntity {
     @Id
@@ -36,4 +34,15 @@ public class Users extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "users", fetch = FetchType.LAZY)
     private List<Memoir> memoirList = new ArrayList<>();
+
+    @Builder
+    public Users(Long id, String social_id, String nickname, String introduction, String memo, List<Memoir> memoirList){
+        this.Id = id;
+        this.social_id = social_id;
+        this.nickname = nickname;
+        this.introduction = introduction;
+        this.memo = memo;
+        this.memoirList = memoirList;
+
+    }
 }

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -12,7 +12,8 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-
+@NoArgsConstructor
+@Getter
 @Entity
 public class Users extends BaseTimeEntity {
     @Id

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -36,6 +36,9 @@ public class Users extends BaseTimeEntity {
     @OneToMany(mappedBy = "users", fetch = FetchType.LAZY)
     private List<Memoir> memoirList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "users", fetch = FetchType.LAZY)
+    private List<Goal> goalList = new ArrayList<>();
+
     @Builder
     public Users(Long id, String social_id, String nickname, String introduction, String memo, List<Memoir> memoirList){
         this.Id = id;

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -1,0 +1,39 @@
+package floud.demo.domain;
+
+import floud.demo.common.domain.BaseTimeEntity;
+import floud.demo.domain.Memoir;
+import jakarta.persistence.*;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+public class Users extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_id")
+    private Long Id;
+
+    @Column(nullable = false)
+    private String social_id;
+
+    @Column(length = 50)
+    private String nickname;
+
+    @Column(length = 500)
+    private String introduction;
+
+    @Column(length = 500)
+    private String memo;
+
+    @OneToMany(mappedBy = "users", fetch = FetchType.LAZY)
+    private List<Memoir> memoirList = new ArrayList<>();
+}

--- a/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
+++ b/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
@@ -14,12 +14,13 @@ public class MemoirCreateRequestDto {
     private String problem_memoir;
     private String try_memoir;
 
-    public Memoir toEntity(){
+    public Memoir toEntity(Users users){
         return Memoir.builder()
                 .title(title)
                 .keep_memoir(keep_memoir)
                 .problem_memoir(problem_memoir)
                 .try_memoir(try_memoir)
+                .users(users)
                 .build();
     }
 }

--- a/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
+++ b/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
@@ -1,5 +1,7 @@
 package floud.demo.dto.memoir;
 
+import floud.demo.domain.Memoir;
+import floud.demo.domain.Users;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,7 +9,17 @@ import lombok.Getter;
 @Builder
 @Getter
 public class MemoirCreateRequestDto {
+    private String title;
     private String keep_memoir;
     private String problem_memoir;
     private String try_memoir;
+
+    public Memoir toEntity(){
+        return Memoir.builder()
+                .title(title)
+                .keep_memoir(keep_memoir)
+                .problem_memoir(problem_memoir)
+                .try_memoir(try_memoir)
+                .build();
+    }
 }

--- a/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
+++ b/src/main/java/floud/demo/dto/memoir/MemoirCreateRequestDto.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.memoir;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Builder
+@Getter
+public class MemoirCreateRequestDto {
+    private String keep_memoir;
+    private String problem_memoir;
+    private String try_memoir;
+}

--- a/src/main/java/floud/demo/dto/memoir/MemoirUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/memoir/MemoirUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package floud.demo.dto.memoir;
+
+import lombok.Getter;
+
+@Getter
+public class MemoirUpdateRequestDto {
+    private String title;
+    private String keep_memoir;
+    private String problem_memoir;
+    private String try_memoir;
+}

--- a/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
+++ b/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
@@ -1,0 +1,12 @@
+package floud.demo.dto.memoir;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public class MultiMemoir {
+    private Long memoir_id;
+    private String title;
+    private LocalDateTime created_at;
+}

--- a/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
+++ b/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
@@ -1,9 +1,11 @@
 package floud.demo.dto.memoir;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 public class MultiMemoir {
     private Long memoir_id;

--- a/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
+++ b/src/main/java/floud/demo/dto/memoir/MultiMemoir.java
@@ -3,12 +3,12 @@ package floud.demo.dto.memoir;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
 public class MultiMemoir {
     private Long memoir_id;
     private String title;
-    private LocalDateTime created_at;
+    private LocalDate created_at;
 }

--- a/src/main/java/floud/demo/dto/memoir/MultiMemoirResponseDto.java
+++ b/src/main/java/floud/demo/dto/memoir/MultiMemoirResponseDto.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.memoir;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MultiMemoirResponseDto {
+    private String nickname;
+    private List<MultiMemoir> memoirList;
+}

--- a/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
+++ b/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
@@ -3,7 +3,7 @@ package floud.demo.dto.memoir;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -14,5 +14,5 @@ public class OneMemoirResponseDto {
     private String keep_memoir;
     private String problem_memoir;
     private String try_memoir;
-    private LocalDateTime created_at;
+    private LocalDate created_at;
 }

--- a/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
+++ b/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
@@ -3,6 +3,8 @@ package floud.demo.dto.memoir;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class OneMemoirResponseDto {
@@ -12,4 +14,5 @@ public class OneMemoirResponseDto {
     private String keep_memoir;
     private String problem_memoir;
     private String try_memoir;
+    private LocalDateTime created_at;
 }

--- a/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
+++ b/src/main/java/floud/demo/dto/memoir/OneMemoirResponseDto.java
@@ -1,0 +1,15 @@
+package floud.demo.dto.memoir;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OneMemoirResponseDto {
+    private String nickname;
+    private Long memoir_id;
+    private String title;
+    private String keep_memoir;
+    private String problem_memoir;
+    private String try_memoir;
+}

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -3,6 +3,6 @@ package floud.demo.repository;
 import floud.demo.domain.Memoir;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemoirRepository  extends JpaRepository<Long, Memoir> {
+public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
 
 }

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -1,0 +1,8 @@
+package floud.demo.repository;
+
+import floud.demo.domain.Memoir;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoirRepository  extends JpaRepository<Long, Memoir> {
+
+}

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -4,6 +4,7 @@ import floud.demo.domain.Memoir;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -11,16 +12,16 @@ import java.util.Optional;
 public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
 
     @Query(value = "SELECT * FROM memoir m WHERE m.users_id =:users_id AND created_at BETWEEN :startDate AND :endDate", nativeQuery = true)
-    List<Memoir> findAllByWeek(Long users_id, LocalDateTime startDate, LocalDateTime endDate);
+    List<Memoir> findAllByWeek(Long users_id, LocalDate startDate, LocalDate endDate);
 
     @Query(value = "SELECT CASE WHEN COUNT(*) > 0 THEN 'TRUE' ELSE 'FALSE' " +
             "END FROM Memoir m WHERE m.users_id = :users_id " +
-            "AND m.created_at BETWEEN :startTime AND :endTime", nativeQuery = true)
-    boolean existsByUserAndCreatedAtBetween(Long users_id, LocalDateTime startTime ,LocalDateTime endTime);
+            "AND m.created_at = :now", nativeQuery = true)
+    boolean existsByUserAndCreatedAtBetween(Long users_id, LocalDate now);
 
     @Query(value = "SELECT * FROM Memoir m WHERE m.users_id = :users_id " +
-            "AND m.created_at BETWEEN :startTime AND :endTime", nativeQuery = true)
-    Optional<Memoir> findByCreatedAt(Long users_id, LocalDateTime startTime , LocalDateTime endTime);
+            "AND m.created_at = :dateTime", nativeQuery = true)
+    Optional<Memoir> findByCreatedAt(Long users_id, LocalDate dateTime);
 
 
 }

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -11,4 +11,11 @@ public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
 
     @Query(value = "SELECT * FROM memoir m WHERE m.users_id =:users_id AND created_at BETWEEN :startDate AND :endDate", nativeQuery = true)
     List<Memoir> findAllByWeek(Long users_id, LocalDateTime startDate, LocalDateTime endDate);
+
+    @Query(value = "SELECT CASE WHEN COUNT(*) > 0 THEN 'TRUE' ELSE 'FALSE' " +
+            "END FROM Memoir m WHERE m.users_id = :users_id " +
+            "AND m.created_at BETWEEN :startTime AND :endTime", nativeQuery = true)
+    boolean existsByUserAndCreatedAtBetween(Long users_id, LocalDateTime startTime ,LocalDateTime endTime);
+
+
 }

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
 
@@ -16,6 +17,10 @@ public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
             "END FROM Memoir m WHERE m.users_id = :users_id " +
             "AND m.created_at BETWEEN :startTime AND :endTime", nativeQuery = true)
     boolean existsByUserAndCreatedAtBetween(Long users_id, LocalDateTime startTime ,LocalDateTime endTime);
+
+    @Query(value = "SELECT * FROM Memoir m WHERE m.users_id = :users_id " +
+            "AND m.created_at BETWEEN :startTime AND :endTime", nativeQuery = true)
+    Optional<Memoir> findByCreatedAt(Long users_id, LocalDateTime startTime , LocalDateTime endTime);
 
 
 }

--- a/src/main/java/floud/demo/repository/MemoirRepository.java
+++ b/src/main/java/floud/demo/repository/MemoirRepository.java
@@ -2,7 +2,13 @@ package floud.demo.repository;
 
 import floud.demo.domain.Memoir;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface MemoirRepository  extends JpaRepository<Memoir, Long> {
 
+    @Query(value = "SELECT * FROM memoir m WHERE m.users_id =:users_id AND created_at BETWEEN :startDate AND :endDate", nativeQuery = true)
+    List<Memoir> findAllByWeek(Long users_id, LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/src/main/java/floud/demo/repository/UsersRepository.java
+++ b/src/main/java/floud/demo/repository/UsersRepository.java
@@ -1,0 +1,7 @@
+package floud.demo.repository;
+
+import floud.demo.domain.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+}

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -1,0 +1,42 @@
+package floud.demo.service;
+
+import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Error;
+import floud.demo.common.response.Success;
+import floud.demo.domain.Memoir;
+import floud.demo.dto.memoir.OneMemoirResponseDto;
+import floud.demo.repository.MemoirRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class FriendService {
+
+    private final MemoirRepository memoirRepository;
+    @Transactional
+    public ApiResponse<?> getMemoirOfFriend(Long memoir_id){
+        //Checking memoir
+        Optional<Memoir> optionalMemoir = memoirRepository.findById(memoir_id);
+        if(optionalMemoir.isEmpty())
+            return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
+        Memoir memoir = optionalMemoir.get();
+
+        OneMemoirResponseDto responseDto = OneMemoirResponseDto.builder()
+                .nickname(memoir.getUsers().getNickname())
+                .memoir_id(memoir.getId())
+                .title(memoir.getTitle())
+                .keep_memoir(memoir.getKeep_memoir())
+                .problem_memoir(memoir.getProblem_memoir())
+                .try_memoir(memoir.getTry_memoir())
+                .created_at(memoir.getCreated_at())
+                .build();
+
+        return  ApiResponse.success(Success.GET_FRIEND_MEMOIR_SUCCESS, responseDto);
+
+    }
+
+}

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -4,22 +4,35 @@ import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
 import floud.demo.domain.Memoir;
+import floud.demo.domain.Users;
 import floud.demo.dto.memoir.MemoirCreateRequestDto;
 import floud.demo.repository.MemoirRepository;
+import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
+import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MemoirService {
+    private final UsersRepository usersRepository;
     private final MemoirRepository memoirRepository;
 
     @Transactional
     public ApiResponse<?> createMemoir(MemoirCreateRequestDto memoirCreateRequestDto){
-        Memoir newMemoir = memoirCreateRequestDto.toEntity();
+        Optional<Users> users = usersRepository.findById(1L);
+        if(users.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        log.info("유저 이름 -> {}", users.get().getNickname());
+
+        Memoir newMemoir = memoirCreateRequestDto.toEntity(users.get());
+        memoirRepository.save(newMemoir);
         return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
     }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -75,6 +76,19 @@ public class MemoirService {
                 .build();
 
         return  ApiResponse.success(Success.ONE_MEMOIR_GET_SUCCESS, responseDto);
+
+    }
+
+    @Transactional
+    public ApiResponse<?> getThisWeekMemoir(LocalDateTime startDate){
+        //Checking user
+        Optional<Users> users = usersRepository.findById(1L);
+        if(users.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        log.info("유저 이름 -> {}", users.get().getNickname());
+
+
+        return  ApiResponse.success(Success.MULTIPLE_MEMOIR_GET_SUCCESS);
 
     }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -42,7 +42,7 @@ public class MemoirService {
         //Create Memoir
         Memoir newMemoir = memoirCreateRequestDto.toEntity(users.get());
         memoirRepository.save(newMemoir);
-        return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
+        return ApiResponse.success(Success.CREATE_MEMOIR_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
     }
 
     @Transactional
@@ -62,7 +62,7 @@ public class MemoirService {
         //Update Memoir
         memoir.update(memoirUpdateRequestDto);
 
-        return  ApiResponse.success(Success.MEMOIR_UPDATE_SUCCESS, Map.of("memoir_id", memoir.getId()));
+        return  ApiResponse.success(Success.UPDATE_MEMOIR_SUCCESS, Map.of("memoir_id", memoir.getId()));
     }
 
     @Transactional
@@ -123,7 +123,7 @@ public class MemoirService {
                 .memoirList(multiMemoirs)
                 .build();
 
-        return  ApiResponse.success(Success.MULTIPLE_MEMOIR_GET_SUCCESS, responseDto);
+        return  ApiResponse.success(Success.GET_MULTIPLE_MEMOIR_SUCCESS, responseDto);
 
     }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -6,11 +6,11 @@ import floud.demo.common.response.Success;
 import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
 import floud.demo.dto.memoir.MemoirCreateRequestDto;
+import floud.demo.dto.memoir.MemoirUpdateRequestDto;
 import floud.demo.repository.MemoirRepository;
 import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.catalina.User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +26,7 @@ public class MemoirService {
 
     @Transactional
     public ApiResponse<?> createMemoir(MemoirCreateRequestDto memoirCreateRequestDto){
+        //Checking user
         Optional<Users> users = usersRepository.findById(1L);
         if(users.isEmpty())
             return ApiResponse.failure(Error.USERS_NOT_FOUND);
@@ -34,5 +35,25 @@ public class MemoirService {
         Memoir newMemoir = memoirCreateRequestDto.toEntity(users.get());
         memoirRepository.save(newMemoir);
         return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
+    }
+
+    @Transactional
+    public ApiResponse<?> updateMemoir(Long memoir_id, MemoirUpdateRequestDto memoirUpdateRequestDto){
+        //Checking user
+        Optional<Users> users = usersRepository.findById(1L);
+        if(users.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        log.info("유저 이름 -> {}", users.get().getNickname());
+
+        //Checking memoir
+        Optional<Memoir> optionalMemoir = memoirRepository.findById(memoir_id);
+        if(optionalMemoir.isEmpty())
+            return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
+        Memoir memoir = optionalMemoir.get();
+
+        //Update Memoir
+        memoir.update(memoirUpdateRequestDto);
+
+        return  ApiResponse.success(Success.MEMOIR_UPDATE_SUCCESS, Map.of("memoir_id", memoir.getId()));
     }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -68,11 +68,21 @@ public class MemoirService {
     }
 
     @Transactional
-    public ApiResponse<?> getOneMemoir(Long memoir_id){
-        //Checking memoir
-        Optional<Memoir> optionalMemoir = memoirRepository.findById(memoir_id);
+    public ApiResponse<?> getOneMemoir(LocalDateTime dateTime){
+        //Checking user
+        Optional<Users> users = usersRepository.findById(1L);
+        if(users.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        log.info("유저 이름 -> {}", users.get().getNickname());
+
+        //Check whether user posts today's memoir
+        LocalDateTime startTime = dateTime.truncatedTo(ChronoUnit.DAYS);
+        LocalDateTime endTime = startTime.plusDays(1);
+        Optional<Memoir> optionalMemoir = memoirRepository.findByCreatedAt(users.get().getId(), startTime, endTime);
+
         if(optionalMemoir.isEmpty())
             return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
+
         Memoir memoir = optionalMemoir.get();
 
         OneMemoirResponseDto responseDto = OneMemoirResponseDto.builder()
@@ -85,7 +95,7 @@ public class MemoirService {
                 .created_at(memoir.getCreated_at())
                 .build();
 
-        return  ApiResponse.success(Success.ONE_MEMOIR_GET_SUCCESS, responseDto);
+        return  ApiResponse.success(Success.GET_MY_MEMOIR_SUCCESS, responseDto);
 
     }
 

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -1,12 +1,16 @@
 package floud.demo.service;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Memoir;
 import floud.demo.dto.memoir.MemoirCreateRequestDto;
 import floud.demo.repository.MemoirRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -15,6 +19,7 @@ public class MemoirService {
 
     @Transactional
     public ApiResponse<?> createMemoir(MemoirCreateRequestDto memoirCreateRequestDto){
-        return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS);
+        Memoir newMemoir = memoirCreateRequestDto.toEntity();
+        return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
     }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -34,6 +35,13 @@ public class MemoirService {
             return ApiResponse.failure(Error.USERS_NOT_FOUND);
         log.info("유저 이름 -> {}", users.get().getNickname());
 
+        //Check whether user posts today's memoir
+        LocalDateTime startTime = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
+        LocalDateTime endTime = startTime.plusDays(1);
+        if(memoirRepository.existsByUserAndCreatedAtBetween(users.get().getId(), startTime, endTime))
+            return ApiResponse.failure(Error.MEMOIR_ALREADY_EXIST);
+
+        //Create Memoir
         Memoir newMemoir = memoirCreateRequestDto.toEntity(users.get());
         memoirRepository.save(newMemoir);
         return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS, Map.of("memoir_id", newMemoir.getId()));

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -80,7 +80,7 @@ public class MemoirService {
     }
 
     @Transactional
-    public ApiResponse<?> getThisWeekMemoir(LocalDateTime startDate){
+    public ApiResponse<?> getWeekMemoir(LocalDateTime startDate){
         //Checking user
         Optional<Users> users = usersRepository.findById(1L);
         if(users.isEmpty())

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -69,10 +69,12 @@ public class MemoirService {
 
         OneMemoirResponseDto responseDto = OneMemoirResponseDto.builder()
                 .nickname(memoir.getUsers().getNickname())
+                .memoir_id(memoir.getId())
                 .title(memoir.getTitle())
                 .keep_memoir(memoir.getKeep_memoir())
                 .problem_memoir(memoir.getProblem_memoir())
                 .try_memoir(memoir.getTry_memoir())
+                .created_at(memoir.getCreated_at())
                 .build();
 
         return  ApiResponse.success(Success.ONE_MEMOIR_GET_SUCCESS, responseDto);

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -13,8 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,9 +35,8 @@ public class MemoirService {
         log.info("유저 이름 -> {}", users.get().getNickname());
 
         //Check whether user posts today's memoir
-        LocalDateTime startTime = LocalDateTime.now().truncatedTo(ChronoUnit.DAYS);
-        LocalDateTime endTime = startTime.plusDays(1);
-        if(memoirRepository.existsByUserAndCreatedAtBetween(users.get().getId(), startTime, endTime))
+        LocalDate now = LocalDate.now();
+        if(memoirRepository.existsByUserAndCreatedAtBetween(users.get().getId(), now))
             return ApiResponse.failure(Error.MEMOIR_ALREADY_EXIST);
 
         //Create Memoir
@@ -68,7 +66,7 @@ public class MemoirService {
     }
 
     @Transactional
-    public ApiResponse<?> getOneMemoir(LocalDateTime dateTime){
+    public ApiResponse<?> getOneMemoir(LocalDate dateTime){
         //Checking user
         Optional<Users> users = usersRepository.findById(1L);
         if(users.isEmpty())
@@ -76,9 +74,7 @@ public class MemoirService {
         log.info("유저 이름 -> {}", users.get().getNickname());
 
         //Check whether user posts today's memoir
-        LocalDateTime startTime = dateTime.truncatedTo(ChronoUnit.DAYS);
-        LocalDateTime endTime = startTime.plusDays(1);
-        Optional<Memoir> optionalMemoir = memoirRepository.findByCreatedAt(users.get().getId(), startTime, endTime);
+        Optional<Memoir> optionalMemoir = memoirRepository.findByCreatedAt(users.get().getId(), dateTime);
 
         if(optionalMemoir.isEmpty())
             return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
@@ -100,7 +96,7 @@ public class MemoirService {
     }
 
     @Transactional
-    public ApiResponse<?> getWeekMemoir(LocalDateTime startDate, LocalDateTime endDate){
+    public ApiResponse<?> getWeekMemoir(LocalDate startDate, LocalDate endDate){
         //Checking user
         Optional<Users> optionalUsers = usersRepository.findById(1L);
         if(optionalUsers.isEmpty())

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -1,9 +1,20 @@
 package floud.demo.service;
 
+import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Success;
+import floud.demo.dto.memoir.MemoirCreateRequestDto;
+import floud.demo.repository.MemoirRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class MemoirService {
+    private final MemoirRepository memoirRepository;
+
+    @Transactional
+    public ApiResponse<?> createMemoir(MemoirCreateRequestDto memoirCreateRequestDto){
+        return ApiResponse.success(Success.MEMOIR_CREATE_SUCCESS);
+    }
 }

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -1,0 +1,9 @@
+package floud.demo.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MemoirService {
+}

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -7,6 +7,7 @@ import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
 import floud.demo.dto.memoir.MemoirCreateRequestDto;
 import floud.demo.dto.memoir.MemoirUpdateRequestDto;
+import floud.demo.dto.memoir.OneMemoirResponseDto;
 import floud.demo.repository.MemoirRepository;
 import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
@@ -55,5 +56,25 @@ public class MemoirService {
         memoir.update(memoirUpdateRequestDto);
 
         return  ApiResponse.success(Success.MEMOIR_UPDATE_SUCCESS, Map.of("memoir_id", memoir.getId()));
+    }
+
+    @Transactional
+    public ApiResponse<?> getOneMemoir(Long memoir_id){
+        //Checking memoir
+        Optional<Memoir> optionalMemoir = memoirRepository.findById(memoir_id);
+        if(optionalMemoir.isEmpty())
+            return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
+        Memoir memoir = optionalMemoir.get();
+
+        OneMemoirResponseDto responseDto = OneMemoirResponseDto.builder()
+                .nickname(memoir.getUsers().getNickname())
+                .title(memoir.getTitle())
+                .keep_memoir(memoir.getKeep_memoir())
+                .problem_memoir(memoir.getProblem_memoir())
+                .try_memoir(memoir.getTry_memoir())
+                .build();
+
+        return  ApiResponse.success(Success.ONE_MEMOIR_GET_SUCCESS, responseDto);
+
     }
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -1,0 +1,17 @@
+package floud.demo.service;
+
+import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Success;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class MyPageService {
+
+    @Transactional
+    public ApiResponse<?> getMypage(){
+        return ApiResponse.success(Success.SUCCESS);
+    }
+}


### PR DESCRIPTION
`Memoir`
- Users, memoir 엔티티를 생성하고 관계를 정의하였습니다.
- 회고 작성 api 를 작성하였습니다.
- 회고 수정 api를 작성하였습니다. 
- 단일 회고 조회 api를 작성하였습니다.
- 주차별 회고 조회 api를 작성하였습니다. 
- 유저 정보와 회고가 없는 경우 에러 응답을 보냅니다. 

`변경사항`
- BaseTimeEntity를 상속 받지 않고 created_at, updated_at 필드을 LocalDate로 선언하여 새로 추가하였습니다.
- 날짜 정보만 가져 오기 위함입니다. 


`Todo`
- 소셜 로그인 완성 후 유저 정보 확인하는 로직을 추가해야 합니다. 
- 유저 정보 확인, 회고 여부 확인 등의  반복되는 로직을 리펙토링 해야 합니다. 