### PR TITLE
Feat: Mypage 구현

### DIFF
--- a/src/main/java/floud/demo/common/domain/BaseDateEntity.java
+++ b/src/main/java/floud/demo/common/domain/BaseDateEntity.java
@@ -1,0 +1,21 @@
+package floud.demo.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDate;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseDateEntity {
+    @CreatedDate
+    LocalDate created_at;
+
+    @LastModifiedDate
+    LocalDate updated_at;
+}

--- a/src/main/java/floud/demo/domain/Goal.java
+++ b/src/main/java/floud/demo/domain/Goal.java
@@ -3,10 +3,12 @@ package floud.demo.domain;
 import floud.demo.common.domain.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@Getter
 @NoArgsConstructor
 @Entity
 public class Goal extends BaseTimeEntity {

--- a/src/main/java/floud/demo/domain/Memoir.java
+++ b/src/main/java/floud/demo/domain/Memoir.java
@@ -1,21 +1,18 @@
 package floud.demo.domain;
 
+import floud.demo.common.domain.BaseDateEntity;
 import floud.demo.dto.memoir.MemoirUpdateRequestDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
-@EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Memoir{
+public class Memoir extends BaseDateEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "memoir_id")
@@ -32,15 +29,6 @@ public class Memoir{
 
     @Column
     private String try_memoir;
-
-    //YYYY-MM-DD 형식으로 변경
-    @CreatedDate
-    @Column
-    private LocalDate created_at;
-
-    @LastModifiedDate
-    @Column
-    private  LocalDate updated_at;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")

--- a/src/main/java/floud/demo/dto/mypage/MyGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/MyGoal.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import java.time.LocalDateTime;
 
 @Getter
-public class myGoal {
+public class MyGoal {
     private Long goal_id;
     private String content;
     private LocalDateTime deadline;

--- a/src/main/java/floud/demo/dto/mypage/MyGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/MyGoal.java
@@ -1,10 +1,12 @@
 package floud.demo.dto.mypage;
 
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Builder
 @Getter
 public class MyGoal {
     private Long goal_id;

--- a/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
@@ -1,0 +1,14 @@
+package floud.demo.dto.mypage;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MypageResponseDto {
+    private String nickname;
+    private String introduction;
+    private List<myGoal> goalList;
+}

--- a/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 public class MypageResponseDto {
     private String nickname;
     private String introduction;
-    private List<myGoal> goalList;
+    private List<MyGoal> goalList;
 }

--- a/src/main/java/floud/demo/dto/mypage/myGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/myGoal.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.mypage;
+
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class myGoal {
+    private Long goal_id;
+    private String content;
+    private LocalDateTime deadline;
+}

--- a/src/main/java/floud/demo/repository/GoalRepository.java
+++ b/src/main/java/floud/demo/repository/GoalRepository.java
@@ -1,0 +1,12 @@
+package floud.demo.repository;
+
+import floud.demo.domain.Goal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface GoalRepository extends JpaRepository<Goal, Long> {
+    @Query(value = "SELECT * FROM goal g WHERE g.users_id = :users_id", nativeQuery = true)
+    List<Goal> findAllByUserId(Long users_id);
+}

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -1,17 +1,55 @@
 package floud.demo.service;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Goal;
+import floud.demo.domain.Users;
+import floud.demo.dto.mypage.MyGoal;
+import floud.demo.dto.mypage.MypageResponseDto;
+import floud.demo.repository.GoalRepository;
+import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MyPageService {
-
+    private final UsersRepository usersRepository;
+    private final GoalRepository goalRepository;
     @Transactional
     public ApiResponse<?> getMypage(){
-        return ApiResponse.success(Success.SUCCESS);
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
+
+        List<Goal> goals = goalRepository.findAllByUserId(users.getId());
+        List<MyGoal> goalList = goals.stream()
+                .map(goal -> MyGoal.builder()
+                        .goal_id(goal.getId())
+                        .content(goal.getContent())
+                        .deadline(goal.getDeadLine())
+                        .build())
+                .collect(Collectors.toList());
+
+
+        MypageResponseDto responseDto = MypageResponseDto.builder()
+                .nickname(users.getNickname())
+                .introduction(users.getIntroduction())
+                .goalList(goalList)
+                .build();
+
+
+        return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, responseDto);
     }
 }


### PR DESCRIPTION
`BaseDateEntity`
- 날짜만 저장하는 BaseDateEntity 추가하였습니다. 
- Memoir에서 BaseDateEntity 상속 받도록 변경했습니다.

`Mypage`
- Goal Entity 생성 후 Users와 일대다 맵핑하였습니다. 
- 마이페이지 조회 구현하였습니다. 
- 임시로 사용자의 아이디 검색 후 회원 정보를 가져옵니다. 

`Todo`
- 소셜 로그인 후 토큰으로 회원 정보 받아오기
- 리펙토링