### PR TITLE
Feat: Mypage 수정, 닉네임 중복체크 구현

### DIFF
--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -20,6 +20,7 @@ public enum Success {
     GET_MYPAGE_SUCCESS(HttpStatus.OK , "마이페이지를 성공적으로 조회하였습니다."),
     GET_MYPAGE_COMMUNITY_SUCCESS(HttpStatus.OK , "내가 쓴 글을 성공적으로 조회하였습니다."),
     REJECT_MY_FRIEND_SUCCESS(HttpStatus.OK , "성공적으로 친구 관계를 삭제하였습니다."),
+    CHECK_NICKNAME_DUPLICATED(HttpStatus.OK , "성공적으로 닉네임 중복을 확인하였습니다."),
 
     //201 CREATED SUCCESS
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -3,6 +3,7 @@ package floud.demo.controller;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.dto.mypage.MypageUpdateRequestDto;
 import floud.demo.service.MyPageService;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +15,10 @@ public class MypageController {
     @GetMapping
     public ApiResponse<?> getMypage(){
         return myPageService.getMypage();
+    }
+    @GetMapping("/check")
+    public ApiResponse<?> checkDuplicatedName(@RequestParam(name = "nickname") String nickname){
+        return  myPageService.checkDuplicatedName(nickname);
     }
 
     @PutMapping

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -1,11 +1,11 @@
 package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.dto.mypage.MypageUpdateRequestDto;
 import floud.demo.service.MyPageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/mypage")
@@ -14,5 +14,10 @@ public class MypageController {
     @GetMapping
     public ApiResponse<?> getMypage(){
         return myPageService.getMypage();
+    }
+
+    @PutMapping
+    public ApiResponse<?> updateMypage(@RequestBody MypageUpdateRequestDto mypageUpdateRequestDto) {
+        return myPageService.updateMypage(mypageUpdateRequestDto);
     }
 }

--- a/src/main/java/floud/demo/domain/Goal.java
+++ b/src/main/java/floud/demo/domain/Goal.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor
@@ -21,21 +21,21 @@ public class Goal extends BaseTimeEntity {
     private String content;
 
     @Column(nullable = false)
-    private LocalDateTime deadline;
+    private LocalDate deadline;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private Users users;
 
     @Builder
-    public Goal(Long id, String content, LocalDateTime deadline, Users users){
+    public Goal(Long id, String content, LocalDate deadline, Users users){
         this.id = id;
         this.content = content;
         this.deadline = deadline;
         this.users = users;
     }
 
-    public void update(String content, LocalDateTime deadline){
+    public void update(String content, LocalDate deadline){
         this.content = content;
         this.deadline = deadline;
     }

--- a/src/main/java/floud/demo/domain/Goal.java
+++ b/src/main/java/floud/demo/domain/Goal.java
@@ -21,16 +21,23 @@ public class Goal extends BaseTimeEntity {
     private String content;
 
     @Column(nullable = false)
-    private LocalDateTime deadLine;
+    private LocalDateTime deadline;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "users_id")
     private Users users;
 
     @Builder
-    public Goal(Long id, String content, LocalDateTime deadLine){
+    public Goal(Long id, String content, LocalDateTime deadline, Users users){
         this.id = id;
         this.content = content;
-        this.deadLine = deadLine;
+        this.deadline = deadline;
+        this.users = users;
     }
+
+    public void update(String content, LocalDateTime deadline){
+        this.content = content;
+        this.deadline = deadline;
+    }
+
 }

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -49,4 +49,8 @@ public class Users extends BaseTimeEntity {
         this.memoirList = memoirList;
 
     }
+
+    public void updateIntroduction(String introduction){
+        this.introduction = introduction;
+    }
 }

--- a/src/main/java/floud/demo/dto/mypage/MyGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/MyGoal.java
@@ -4,6 +4,7 @@ package floud.demo.dto.mypage;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
@@ -11,5 +12,5 @@ import java.time.LocalDateTime;
 public class MyGoal {
     private Long goal_id;
     private String content;
-    private LocalDateTime deadline;
+    private LocalDate deadline;
 }

--- a/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
@@ -9,5 +9,5 @@ import java.util.List;
 public class MypageUpdateRequestDto {
     private String nickname;
     private String introduction;
-    private List<Goal> goalList;
+    private List<UpdateGoal> goalList;
 }

--- a/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.Goal;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MypageUpdateRequestDto {
+    private String nickname;
+    private String introduction;
+    private List<Goal> goalList;
+}

--- a/src/main/java/floud/demo/dto/mypage/UpdateGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/UpdateGoal.java
@@ -5,13 +5,14 @@ import floud.demo.domain.Users;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Builder
 @Getter
 public class UpdateGoal {
     private String content;
-    private LocalDateTime deadline;
+    private LocalDate deadline;
 
     public Goal toEntity(Users users){
         return Goal.builder()

--- a/src/main/java/floud/demo/dto/mypage/UpdateGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/UpdateGoal.java
@@ -1,0 +1,23 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.Goal;
+import floud.demo.domain.Users;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class UpdateGoal {
+    private String content;
+    private LocalDateTime deadline;
+
+    public Goal toEntity(Users users){
+        return Goal.builder()
+                .content(content)
+                .deadline(deadline)
+                .users(users)
+                .build();
+    }
+}

--- a/src/main/java/floud/demo/repository/UsersRepository.java
+++ b/src/main/java/floud/demo/repository/UsersRepository.java
@@ -2,6 +2,8 @@ package floud.demo.repository;
 
 import floud.demo.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -55,6 +55,7 @@ public class MyPageService {
         return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, responseDto);
     }
 
+    @Transactional
     public ApiResponse<?> updateMypage(MypageUpdateRequestDto requestDto){
         //Checking user
         Optional<Users> optionalUsers = usersRepository.findById(1L);
@@ -70,4 +71,6 @@ public class MyPageService {
         //MypageResonsedto 리턴하기
         return ApiResponse.success(Success.UPDATE_MYPAGE_SUCCESS, Map.of("nicknmae", requestDto.getNickname()));
     }
+
+
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -48,8 +48,8 @@ public class MyPageService {
 
     @Transactional
     public ApiResponse<?> checkDuplicatedName(String nickname){
-
-        return ApiResponse.success(Success.SUCCESS);
+        boolean isDuplicated = usersRepository.existsByNickname(nickname);
+        return ApiResponse.success(Success.CHECK_NICKNAME_DUPLICATED, Map.of("isDuplicated", isDuplicated));
     }
 
     @Transactional

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -35,24 +35,14 @@ public class MyPageService {
         Users users = optionalUsers.get();
         log.info("유저 이름 -> {}", users.getNickname());
 
-        List<Goal> goals = goalRepository.findAllByUserId(users.getId());
-        List<MyGoal> goalList = goals.stream()
-                .map(goal -> MyGoal.builder()
-                        .goal_id(goal.getId())
-                        .content(goal.getContent())
-                        .deadline(goal.getDeadLine())
-                        .build())
-                .collect(Collectors.toList());
+        //set GoalList
+        List<MyGoal> goalList = setGoalList(users.getId());
 
-
-        MypageResponseDto responseDto = MypageResponseDto.builder()
+        return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, MypageResponseDto.builder()
                 .nickname(users.getNickname())
                 .introduction(users.getIntroduction())
                 .goalList(goalList)
-                .build();
-
-
-        return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, responseDto);
+                .build());
     }
 
     @Transactional
@@ -72,5 +62,17 @@ public class MyPageService {
         return ApiResponse.success(Success.UPDATE_MYPAGE_SUCCESS, Map.of("nicknmae", requestDto.getNickname()));
     }
 
+    public List<MyGoal> setGoalList(Long users_id){
+        List<Goal> goals = goalRepository.findAllByUserId(users_id);
+        List<MyGoal> goalList = goals.stream()
+                .map(goal -> MyGoal.builder()
+                        .goal_id(goal.getId())
+                        .content(goal.getContent())
+                        .deadline(goal.getDeadLine())
+                        .build())
+                .collect(Collectors.toList());
+
+        return goalList;
+    }
 
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -43,6 +44,12 @@ public class MyPageService {
                 .introduction(users.getIntroduction())
                 .goalList(goalList)
                 .build());
+    }
+
+    @Transactional
+    public ApiResponse<?> checkDuplicatedName(String nickname){
+
+        return ApiResponse.success(Success.SUCCESS);
     }
 
     @Transactional

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -7,6 +7,7 @@ import floud.demo.domain.Goal;
 import floud.demo.domain.Users;
 import floud.demo.dto.mypage.MyGoal;
 import floud.demo.dto.mypage.MypageResponseDto;
+import floud.demo.dto.mypage.MypageUpdateRequestDto;
 import floud.demo.repository.GoalRepository;
 import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -51,5 +53,10 @@ public class MyPageService {
 
 
         return ApiResponse.success(Success.GET_MYPAGE_SUCCESS, responseDto);
+    }
+
+    public ApiResponse<?> updateMypage(MypageUpdateRequestDto requestDto){
+
+        return ApiResponse.success(Success.UPDATE_MYPAGE_SUCCESS, Map.of("nicknmae", requestDto.getNickname()));
     }
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -56,7 +56,18 @@ public class MyPageService {
     }
 
     public ApiResponse<?> updateMypage(MypageUpdateRequestDto requestDto){
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
 
+        //Update Introduction
+        users.updateIntroduction(requestDto.getIntroduction());
+        usersRepository.save(users);
+
+        //MypageResonsedto 리턴하기
         return ApiResponse.success(Success.UPDATE_MYPAGE_SUCCESS, Map.of("nicknmae", requestDto.getNickname()));
     }
 }


### PR DESCRIPTION
`Mypage`
- goalList 구성하는 로직을 분리하여 리펙토링하였습니다. 
- Mypage 정보를 입력받아 수정하는 api를 작성하였습니다. 
  - 자기소개 introduction 필드를 수정합니다. 
  - 기존 goal을 모두 지우고 새로 생성합니다. 
- Mypage에서 닉네임 중복을 확인하는 api를 작성하였습니다. 
- Goal 저장 시 날짜만 저장하도록 변경하였습니다. 

`Todo`
- 소셜 로그인 구현 후 유저 정보 받아오는 로직 추가