### PR TITLE
Feat: Mypage의 친구 관리 api 구현

### DIFF
--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -20,7 +20,7 @@ public enum Error {
     // 409 CONFLICT
     MEMOIR_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 오늘의 회고를 작성하였습니다."),
     FRIENDSHIP_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 친구 관계가 존재합니다."),
-
+    NOT_MATCHED_NICKNAME(HttpStatus.CONFLICT, "친구 관계 정보가 일치하지 않습니다."),
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -13,10 +13,13 @@ public enum Error {
 
     // 404 NOT FOUND
     USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
+    FRIEND_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 닉네임의 회원을 찾을 수 없습니다."),
     MEMOIR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회고를 찾을 수 없습니다."),
 
     // 409 CONFLICT
     MEMOIR_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 오늘의 회고를 작성하였습니다."),
+    FRIENDSHIP_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 친구 관계가 존재합니다."),
+
 
     // 500 INTERNAL SERVER ERROR
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -14,6 +14,7 @@ public enum Error {
     // 404 NOT FOUND
     USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     FRIEND_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 닉네임의 회원을 찾을 수 없습니다."),
+    FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 친구 관계를 찾을 수 없습니다."),
     MEMOIR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 회고를 찾을 수 없습니다."),
 
     // 409 CONFLICT

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -23,6 +23,7 @@ public enum Success {
 
     GET_FRIEND_LIST_SUCCESS(HttpStatus.OK , "나의 친구 목록을 성공적으로 조회하였습니다."),
     GET_FRIEND_MEMOIR_SUCCESS(HttpStatus.OK , "친구의 회고를 성공적으로 조회하였습니다."),
+    DELETE_FRIEND_SUCCESS(HttpStatus.OK , "친구를 성공적으로 삭제하였습니다."),
 
     //201 CREATED SUCCESS
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -27,7 +27,7 @@ public enum Success {
     //201 CREATED SUCCESS
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     UPDATE_MYPAGE_SUCCESS(HttpStatus.CREATED , "마이페이지를 성공적으로 수정하였습니다."),
-    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보냈였습니다. "),
+    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보내었습니다. "),
     ACCEPT_FRIEND_SUCCESS(HttpStatus.CREATED , "성공적으로 친구 수락을 완료하였습니다. "),
     ;
 

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -27,8 +27,8 @@ public enum Success {
     //201 CREATED SUCCESS
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     UPDATE_MYPAGE_SUCCESS(HttpStatus.CREATED , "마이페이지를 성공적으로 수정하였습니다."),
-    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보내었습니다. "),
-    ACCEPT_FRIEND_SUCCESS(HttpStatus.CREATED , "성공적으로 친구 수락을 완료하였습니다. "),
+    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보내었습니다."),
+    UPDATE_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 상태를 성공적으로 변경하였습니다."),
     ;
 
 

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -14,7 +14,6 @@ public enum Success {
     //200 SUCCESS
     UPDATE_MEMOIR_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
     GET_MY_MEMOIR_SUCCESS(HttpStatus.OK , "나의 회고를 성공적으로 조회하였습니다."),
-    GET_FRIEND_MEMOIR_SUCCESS(HttpStatus.OK , "친구의 회고를 성공적으로 조회하였습니다."),
     GET_MULTIPLE_MEMOIR_SUCCESS(HttpStatus.OK , "주차별 회고 목록을 성공적으로 조회하였습니다."),
 
     GET_MYPAGE_SUCCESS(HttpStatus.OK , "마이페이지를 성공적으로 조회하였습니다."),
@@ -22,10 +21,14 @@ public enum Success {
     REJECT_MY_FRIEND_SUCCESS(HttpStatus.OK , "성공적으로 친구 관계를 삭제하였습니다."),
     CHECK_NICKNAME_DUPLICATED(HttpStatus.OK , "성공적으로 닉네임 중복을 확인하였습니다."),
 
+    GET_FRIEND_LIST_SUCCESS(HttpStatus.OK , "나의 친구 목록을 성공적으로 조회하였습니다."),
+    GET_FRIEND_MEMOIR_SUCCESS(HttpStatus.OK , "친구의 회고를 성공적으로 조회하였습니다."),
+
     //201 CREATED SUCCESS
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     UPDATE_MYPAGE_SUCCESS(HttpStatus.CREATED , "마이페이지를 성공적으로 수정하였습니다."),
-    ACCEPT_MY_FRIEND_SUCCESS(HttpStatus.CREATED , "성공적으로 친구 수락을 완료하였습니다. "),
+    REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보냈였습니다. "),
+    ACCEPT_FRIEND_SUCCESS(HttpStatus.CREATED , "성공적으로 친구 수락을 완료하였습니다. "),
     ;
 
 

--- a/src/main/java/floud/demo/controller/FriendController.java
+++ b/src/main/java/floud/demo/controller/FriendController.java
@@ -14,6 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
     private final FriendService friendService;
 
+    @GetMapping
+    public ApiResponse<?> getFriends(){
+        return friendService.getFriends();
+    }
+
     @GetMapping("memoir/{memoir_id}")
     public ApiResponse<?> getOneMemoir(@PathVariable Long memoir_id){
         return friendService.getMemoirOfFriend(memoir_id);

--- a/src/main/java/floud/demo/controller/FriendController.java
+++ b/src/main/java/floud/demo/controller/FriendController.java
@@ -3,10 +3,9 @@ package floud.demo.controller;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.service.FriendService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RequiredArgsConstructor
 @RestController
@@ -14,9 +13,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
     private final FriendService friendService;
 
-    @GetMapping
-    public ApiResponse<?> getFriends(){
-        return friendService.getFriends();
+    @GetMapping("/my")
+    public ApiResponse<?> getFriendsInfo(@RequestParam(name = "date") LocalDate date){
+        return friendService.getFriendsInfo(date);
     }
 
     @GetMapping("memoir/{memoir_id}")

--- a/src/main/java/floud/demo/controller/FriendController.java
+++ b/src/main/java/floud/demo/controller/FriendController.java
@@ -19,7 +19,7 @@ public class FriendController {
         return friendService.getFriendsInfo(date);
     }
 
-    @PostMapping()
+    @PostMapping("/request")
     public ApiResponse<?> addFriend(@RequestBody FriendshipCreateRequestDto requestDto){
         return friendService.addFriend(requestDto);
     }

--- a/src/main/java/floud/demo/controller/FriendController.java
+++ b/src/main/java/floud/demo/controller/FriendController.java
@@ -1,6 +1,7 @@
 package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.dto.friendship.FriendshipCreateRequestDto;
 import floud.demo.service.FriendService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -16,6 +17,11 @@ public class FriendController {
     @GetMapping("/my")
     public ApiResponse<?> getFriendsInfo(@RequestParam(name = "date") LocalDate date){
         return friendService.getFriendsInfo(date);
+    }
+
+    @PostMapping()
+    public ApiResponse<?> addFriend(@RequestBody FriendshipCreateRequestDto requestDto){
+        return friendService.addFriend(requestDto);
     }
 
     @GetMapping("memoir/{memoir_id}")

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -33,7 +33,7 @@ public class MypageController {
     }
 
     @PutMapping("/friend")
-    public ApiResponse<?> acceptFriend(@RequestBody MypageFriendUpdateRequestDto requestDto){
-        return myPageService.acceptFriend(requestDto);
+    public ApiResponse<?> updateFriend(@RequestBody MypageFriendUpdateRequestDto requestDto){
+        return myPageService.updateFriend(requestDto);
     }
 }

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -36,4 +36,9 @@ public class MypageController {
     public ApiResponse<?> updateFriend(@RequestBody MypageFriendUpdateRequestDto requestDto){
         return myPageService.updateFriend(requestDto);
     }
+
+    @PutMapping("/friend/{friendship_id}")
+    public ApiResponse<?> deleteFriend(@PathVariable(name = "friendship_id") Long friendship_id){
+        return myPageService.deleteFriend(friendship_id);
+    }
 }

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -16,6 +16,7 @@ public class MypageController {
     public ApiResponse<?> getMypage(){
         return myPageService.getMypage();
     }
+
     @GetMapping("/check")
     public ApiResponse<?> checkDuplicatedName(@RequestParam(name = "nickname") String nickname){
         return  myPageService.checkDuplicatedName(nickname);
@@ -24,5 +25,10 @@ public class MypageController {
     @PutMapping
     public ApiResponse<?> updateMypage(@RequestBody MypageUpdateRequestDto mypageUpdateRequestDto) {
         return myPageService.updateMypage(mypageUpdateRequestDto);
+    }
+
+    @GetMapping("/friend")
+    public ApiResponse<?> getFriendList(){
+        return myPageService.getFriendList();
     }
 }

--- a/src/main/java/floud/demo/controller/MypageController.java
+++ b/src/main/java/floud/demo/controller/MypageController.java
@@ -1,9 +1,9 @@
 package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.dto.mypage.MypageFriendUpdateRequestDto;
 import floud.demo.dto.mypage.MypageUpdateRequestDto;
 import floud.demo.service.MyPageService;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,5 +30,10 @@ public class MypageController {
     @GetMapping("/friend")
     public ApiResponse<?> getFriendList(){
         return myPageService.getFriendList();
+    }
+
+    @PutMapping("/friend")
+    public ApiResponse<?> acceptFriend(@RequestBody MypageFriendUpdateRequestDto requestDto){
+        return myPageService.acceptFriend(requestDto);
     }
 }

--- a/src/main/java/floud/demo/domain/Friendship.java
+++ b/src/main/java/floud/demo/domain/Friendship.java
@@ -1,0 +1,40 @@
+package floud.demo.domain;
+
+import floud.demo.domain.enums.FriendshipStatus;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Friendship {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "frinedship_id")
+    private Long id;
+
+    @Column
+    @Enumerated(value = EnumType.STRING)
+    private FriendshipStatus friendshipStatus;
+
+    // 친구 신청 송신자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "to_user")
+    private Users to_user;
+
+    // 친구 신청 수신자
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "from_user")
+    private Users from_user;
+
+    @Builder
+    public Friendship(Long id, FriendshipStatus friendshipStatus, Users to_user, Users from_user){
+        this.id = id;
+        this.friendshipStatus = friendshipStatus;
+        this.to_user = to_user;
+        this.from_user = from_user;
+    }
+
+}

--- a/src/main/java/floud/demo/domain/Friendship.java
+++ b/src/main/java/floud/demo/domain/Friendship.java
@@ -37,4 +37,8 @@ public class Friendship {
         this.from_user = from_user;
     }
 
+    public void updateStatus(FriendshipStatus friendshipStatus){
+        this.friendshipStatus = friendshipStatus;
+    }
+
 }

--- a/src/main/java/floud/demo/domain/enums/FriendshipStatus.java
+++ b/src/main/java/floud/demo/domain/enums/FriendshipStatus.java
@@ -1,0 +1,16 @@
+package floud.demo.domain.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum FriendshipStatus {
+    WAITING("WAITING"),
+    ACCEPT("ACCEPT"),
+    REJECT("REJECT");
+
+    private final String friendshipStatus;
+
+    FriendshipStatus(String friendshipStatus) {
+        this.friendshipStatus = friendshipStatus;
+    }
+}

--- a/src/main/java/floud/demo/dto/friendship/FriendshipCreateRequestDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipCreateRequestDto.java
@@ -1,8 +1,19 @@
 package floud.demo.dto.friendship;
 
+import floud.demo.domain.Friendship;
+import floud.demo.domain.Users;
+import floud.demo.domain.enums.FriendshipStatus;
 import lombok.Getter;
 
 @Getter
 public class FriendshipCreateRequestDto {
     private String nickname;
+
+    public Friendship toEntity(Users to_user, Users from_user){
+        return Friendship.builder()
+                .to_user(to_user)
+                .from_user(from_user)
+                .friendshipStatus(FriendshipStatus.WAITING)
+                .build();
+    }
 }

--- a/src/main/java/floud/demo/dto/friendship/FriendshipCreateRequestDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipCreateRequestDto.java
@@ -1,0 +1,8 @@
+package floud.demo.dto.friendship;
+
+import lombok.Getter;
+
+@Getter
+public class FriendshipCreateRequestDto {
+    private String nickname;
+}

--- a/src/main/java/floud/demo/dto/friendship/FriendshipDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipDto.java
@@ -1,0 +1,8 @@
+package floud.demo.dto.friendship;
+
+import java.util.List;
+
+public class FriendshipDto {
+    private String nickname;
+    private List<FriendshipDto> friendshipList;
+}

--- a/src/main/java/floud/demo/dto/friendship/FriendshipDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipDto.java
@@ -1,8 +1,13 @@
 package floud.demo.dto.friendship;
 
-import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
 
+
+@Getter
+@Builder
 public class FriendshipDto {
-    private String nickname;
-    private List<FriendshipDto> friendshipList;
+    private String friend_nickname;
+    private Boolean memoir_status;
+    private Long memoir_id;
 }

--- a/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
@@ -3,8 +3,11 @@ package floud.demo.dto.friendship;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class FriendshipListResponseDto {
-
+    private String my_nickname;
+    private List<FriendshipDto> friendshipList;
 }

--- a/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
@@ -1,0 +1,10 @@
+package floud.demo.dto.friendship;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendshipListResponseDto {
+
+}

--- a/src/main/java/floud/demo/dto/mypage/MyFriend.java
+++ b/src/main/java/floud/demo/dto/mypage/MyFriend.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.enums.FriendshipStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MyFriend {
+    private String nickname;
+    private FriendshipStatus friendshipStatus;
+    private String introduction;
+}

--- a/src/main/java/floud/demo/dto/mypage/MyFriend.java
+++ b/src/main/java/floud/demo/dto/mypage/MyFriend.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class MyFriend {
+    private Long friendship_id;
     private String nickname;
     private FriendshipStatus friendshipStatus;
     private String introduction;

--- a/src/main/java/floud/demo/dto/mypage/MyWaiting.java
+++ b/src/main/java/floud/demo/dto/mypage/MyWaiting.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.enums.FriendshipStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyWaiting {
+    private String nickname;
+    private FriendshipStatus friendshipStatus;
+    private String introduction;
+}

--- a/src/main/java/floud/demo/dto/mypage/MyWaiting.java
+++ b/src/main/java/floud/demo/dto/mypage/MyWaiting.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MyWaiting {
+    private Long friendship_id;
     private String nickname;
     private FriendshipStatus friendshipStatus;
     private String introduction;

--- a/src/main/java/floud/demo/dto/mypage/MypageFriendDeleteResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageFriendDeleteResponseDto.java
@@ -1,0 +1,14 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.enums.FriendshipStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MypageFriendDeleteResponseDto {
+    private Long friendship_id;
+    private String to_user;
+    private String from_user;
+    private FriendshipStatus friendshipStatus;
+}

--- a/src/main/java/floud/demo/dto/mypage/MypageFriendListResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageFriendListResponseDto.java
@@ -1,0 +1,13 @@
+package floud.demo.dto.mypage;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MypageFriendListResponseDto {
+    private List<MyWaiting> waitingList;
+    private List<MyFriend> myFriendList;
+}

--- a/src/main/java/floud/demo/dto/mypage/MypageFriendListResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageFriendListResponseDto.java
@@ -1,5 +1,7 @@
 package floud.demo.dto.mypage;
 
+import floud.demo.dto.mypage.dto.MyFriend;
+import floud.demo.dto.mypage.dto.MyWaiting;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/floud/demo/dto/mypage/MypageFriendUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageFriendUpdateRequestDto.java
@@ -1,0 +1,12 @@
+package floud.demo.dto.mypage;
+
+import floud.demo.domain.enums.FriendshipStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MypageFriendUpdateRequestDto {
+    private String nickname;
+    private FriendshipStatus friendshipStatus;
+}

--- a/src/main/java/floud/demo/dto/mypage/MypageFriendUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageFriendUpdateRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class MypageFriendUpdateRequestDto {
+    private Long friendship_id;
     private String nickname;
     private FriendshipStatus friendshipStatus;
 }

--- a/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageResponseDto.java
@@ -1,5 +1,6 @@
 package floud.demo.dto.mypage;
 
+import floud.demo.dto.mypage.dto.MyGoal;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
+++ b/src/main/java/floud/demo/dto/mypage/MypageUpdateRequestDto.java
@@ -1,6 +1,6 @@
 package floud.demo.dto.mypage;
 
-import floud.demo.domain.Goal;
+import floud.demo.dto.mypage.dto.UpdateGoal;
 import lombok.Getter;
 
 import java.util.List;

--- a/src/main/java/floud/demo/dto/mypage/dto/MyFriend.java
+++ b/src/main/java/floud/demo/dto/mypage/dto/MyFriend.java
@@ -1,12 +1,12 @@
-package floud.demo.dto.mypage;
+package floud.demo.dto.mypage.dto;
 
 import floud.demo.domain.enums.FriendshipStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter
 @Builder
-public class MyWaiting {
+@Getter
+public class MyFriend {
     private Long friendship_id;
     private String nickname;
     private FriendshipStatus friendshipStatus;

--- a/src/main/java/floud/demo/dto/mypage/dto/MyGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/dto/MyGoal.java
@@ -1,4 +1,4 @@
-package floud.demo.dto.mypage;
+package floud.demo.dto.mypage.dto;
 
 
 import lombok.Builder;

--- a/src/main/java/floud/demo/dto/mypage/dto/MyWaiting.java
+++ b/src/main/java/floud/demo/dto/mypage/dto/MyWaiting.java
@@ -1,12 +1,12 @@
-package floud.demo.dto.mypage;
+package floud.demo.dto.mypage.dto;
 
 import floud.demo.domain.enums.FriendshipStatus;
 import lombok.Builder;
 import lombok.Getter;
 
-@Builder
 @Getter
-public class MyFriend {
+@Builder
+public class MyWaiting {
     private Long friendship_id;
     private String nickname;
     private FriendshipStatus friendshipStatus;

--- a/src/main/java/floud/demo/dto/mypage/dto/UpdateGoal.java
+++ b/src/main/java/floud/demo/dto/mypage/dto/UpdateGoal.java
@@ -1,4 +1,4 @@
-package floud.demo.dto.mypage;
+package floud.demo.dto.mypage.dto;
 
 import floud.demo.domain.Goal;
 import floud.demo.domain.Users;

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -25,9 +25,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
             "WHERE f.friendship_status = 'WAITING' AND  f.to_user = :users_id", nativeQuery = true)
     List<Friendship> findAllByWaitingToUser(Long users_id);
 
-    //수락하기 위해 대기 상태인 Friendship 찾기
-    @Query(value = "SELECT * FROM friendship f " +
-            "WHERE f.friendship_status = 'WAITING' AND  f.to_user = :to_user AND f.from_user = :from_user", nativeQuery = true)
-    Friendship findByUserIds(Long to_user, Long from_user);
+    Optional<Friendship> findById(Long id);
 
 }

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -2,6 +2,13 @@ package floud.demo.repository;
 
 import floud.demo.domain.Friendship;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    @Query(value = "SELECT * FROM friendship f " +
+            "WHERE f.friendship_status = 'ACCPET' " +
+            "AND f.to_user = :users_id OR f.from_user = :users_id", nativeQuery = true)
+    List<Friendship> findAllByUsersId(Long users_id);
 }

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -9,7 +9,7 @@ import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query(value = "SELECT * FROM friendship f " +
-            "WHERE f.friendship_status = 'ACCPET' " +
+            "WHERE f.friendship_status = 'ACCEPT' " +
             "AND f.to_user = :users_id OR f.from_user = :users_id", nativeQuery = true)
     List<Friendship> findAllByUsersId(Long users_id);
 

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -5,10 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query(value = "SELECT * FROM friendship f " +
             "WHERE f.friendship_status = 'ACCPET' " +
             "AND f.to_user = :users_id OR f.from_user = :users_id", nativeQuery = true)
     List<Friendship> findAllByUsersId(Long users_id);
+
+    @Query(value = "SELECT * FROM Friendship f " +
+            "WHERE (f.to_user = :toUserId AND f.from_user = :fromUserId) " +
+            "OR (f.to_user = :fromUserId AND f.from_user = :toUserId)",  nativeQuery = true)
+    Optional<Friendship> findByToUserAndFromUser(Long toUserId, Long fromUserId);
+
 }

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -1,0 +1,7 @@
+package floud.demo.repository;
+
+import floud.demo.domain.Friendship;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+}

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -10,12 +10,17 @@ import java.util.Optional;
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     @Query(value = "SELECT * FROM friendship f " +
             "WHERE f.friendship_status = 'ACCEPT' " +
-            "AND f.to_user = :users_id OR f.from_user = :users_id", nativeQuery = true)
+            "AND (f.to_user = :users_id OR f.from_user = :users_id)", nativeQuery = true)
     List<Friendship> findAllByUsersId(Long users_id);
 
     @Query(value = "SELECT * FROM Friendship f " +
             "WHERE (f.to_user = :toUserId AND f.from_user = :fromUserId) " +
             "OR (f.to_user = :fromUserId AND f.from_user = :toUserId)",  nativeQuery = true)
     Optional<Friendship> findByToUserAndFromUser(Long toUserId, Long fromUserId);
+
+    @Query(value = "SELECT * FROM friendship f " +
+            "WHERE f.friendship_status = 'WAITING' AND  f.from_user = :users_id", nativeQuery = true)
+    List<Friendship> findAllByWaitingToUser(Long users_id);
+
 
 }

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -8,19 +8,26 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+    //나랑 친구인 유저 목록
     @Query(value = "SELECT * FROM friendship f " +
             "WHERE f.friendship_status = 'ACCEPT' " +
             "AND (f.to_user = :users_id OR f.from_user = :users_id)", nativeQuery = true)
     List<Friendship> findAllByUsersId(Long users_id);
 
+    //현재 친구 관계가 있는 지 확인
     @Query(value = "SELECT * FROM Friendship f " +
             "WHERE (f.to_user = :toUserId AND f.from_user = :fromUserId) " +
             "OR (f.to_user = :fromUserId AND f.from_user = :toUserId)",  nativeQuery = true)
-    Optional<Friendship> findByToUserAndFromUser(Long toUserId, Long fromUserId);
+    Optional<Friendship> checkExistingFriendship(Long toUserId, Long fromUserId);
 
+    //대기 상태인 친구들
     @Query(value = "SELECT * FROM friendship f " +
-            "WHERE f.friendship_status = 'WAITING' AND  f.from_user = :users_id", nativeQuery = true)
+            "WHERE f.friendship_status = 'WAITING' AND  f.to_user = :users_id", nativeQuery = true)
     List<Friendship> findAllByWaitingToUser(Long users_id);
 
+    //수락하기 위해 대기 상태인 Friendship 찾기
+    @Query(value = "SELECT * FROM friendship f " +
+            "WHERE f.friendship_status = 'WAITING' AND  f.to_user = :to_user AND f.from_user = :from_user", nativeQuery = true)
+    Friendship findByUserIds(Long to_user, Long from_user);
 
 }

--- a/src/main/java/floud/demo/repository/UsersRepository.java
+++ b/src/main/java/floud/demo/repository/UsersRepository.java
@@ -2,8 +2,11 @@ package floud.demo.repository;
 
 import floud.demo.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface UsersRepository extends JpaRepository<Users, Long> {
     boolean existsByNickname(String nickname);
+
+    Optional<Users> findByNickname(String nickname);
 }

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -17,6 +17,11 @@ import java.util.Optional;
 public class FriendService {
 
     private final MemoirRepository memoirRepository;
+
+    @Transactional
+    public ApiResponse<?> getFriends(){
+        return ApiResponse.success(Success.SUCCESS);
+    }
     @Transactional
     public ApiResponse<?> getMemoirOfFriend(Long memoir_id){
         //Checking memoir

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -6,6 +6,7 @@ import floud.demo.common.response.Success;
 import floud.demo.domain.Friendship;
 import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
+import floud.demo.dto.friendship.FriendshipCreateRequestDto;
 import floud.demo.dto.friendship.FriendshipDto;
 import floud.demo.dto.friendship.FriendshipListResponseDto;
 import floud.demo.dto.memoir.OneMemoirResponseDto;
@@ -48,6 +49,12 @@ public class FriendService {
                         .my_nickname(users.getNickname())
                         .friendshipList(friendshipList)
                         .build());
+    }
+
+
+    @Transactional
+    public ApiResponse<?> addFriend(FriendshipCreateRequestDto requestDto){
+        return ApiResponse.success(Success.REQUEST_FRIEND_SUCCESS);
     }
 
     @Transactional

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -74,7 +74,7 @@ public class FriendService {
             return ApiResponse.failure(Error.FRIENDSHIP_ALREADY_EXIST);
         }
         //Create Friendship
-        Friendship newFriendship = requestDto.toEntity(users,friend);
+        Friendship newFriendship = requestDto.toEntity(friend, users);
         friendshipRepository.save(newFriendship);
 
         return ApiResponse.success(Success.REQUEST_FRIEND_SUCCESS, Map.of("friendship_id", newFriendship.getId()));

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
@@ -54,7 +55,24 @@ public class FriendService {
 
     @Transactional
     public ApiResponse<?> addFriend(FriendshipCreateRequestDto requestDto){
-        return ApiResponse.success(Success.REQUEST_FRIEND_SUCCESS);
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
+
+        //Checking friend is existed
+        Optional<Users> optionalFriend = usersRepository.findByNickname(requestDto.getNickname());
+        if(optionalFriend.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users friend = optionalFriend.get();
+
+        //Create Friendship
+        Friendship newFriendship = requestDto.toEntity(users,friend);
+        friendshipRepository.save(newFriendship);
+
+        return ApiResponse.success(Success.REQUEST_FRIEND_SUCCESS, Map.of("friendship_id", newFriendship.getId()));
     }
 
     @Transactional

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -3,25 +3,53 @@ package floud.demo.service;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Friendship;
 import floud.demo.domain.Memoir;
+import floud.demo.domain.Users;
+import floud.demo.dto.friendship.FriendshipDto;
+import floud.demo.dto.friendship.FriendshipListResponseDto;
 import floud.demo.dto.memoir.OneMemoirResponseDto;
+import floud.demo.repository.FriendshipRepository;
 import floud.demo.repository.MemoirRepository;
+import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class FriendService {
 
+    private final UsersRepository usersRepository;
     private final MemoirRepository memoirRepository;
+    private final FriendshipRepository friendshipRepository;
+
 
     @Transactional
-    public ApiResponse<?> getFriends(){
-        return ApiResponse.success(Success.SUCCESS);
+    public ApiResponse<?> getFriendsInfo(LocalDate date){
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
+
+        //친구 정보 가져오기
+        List<FriendshipDto> friendshipList = findFriendInfo(users, date);
+
+        return ApiResponse.success(Success.GET_FRIEND_LIST_SUCCESS, FriendshipListResponseDto.builder()
+                        .my_nickname(users.getNickname())
+                        .friendshipList(friendshipList)
+                        .build());
     }
+
     @Transactional
     public ApiResponse<?> getMemoirOfFriend(Long memoir_id){
         //Checking memoir
@@ -30,7 +58,7 @@ public class FriendService {
             return ApiResponse.failure(Error.MEMOIR_NOT_FOUND);
         Memoir memoir = optionalMemoir.get();
 
-        OneMemoirResponseDto responseDto = OneMemoirResponseDto.builder()
+        return  ApiResponse.success(Success.GET_FRIEND_MEMOIR_SUCCESS, OneMemoirResponseDto.builder()
                 .nickname(memoir.getUsers().getNickname())
                 .memoir_id(memoir.getId())
                 .title(memoir.getTitle())
@@ -38,10 +66,35 @@ public class FriendService {
                 .problem_memoir(memoir.getProblem_memoir())
                 .try_memoir(memoir.getTry_memoir())
                 .created_at(memoir.getCreated_at())
-                .build();
+                .build());
 
-        return  ApiResponse.success(Success.GET_FRIEND_MEMOIR_SUCCESS, responseDto);
+    }
 
+    public List<FriendshipDto> findFriendInfo(Users me, LocalDate date){
+        List<Friendship> myfriends = friendshipRepository.findAllByUsersId(me.getId());
+        List<FriendshipDto> myfriendsInfo = new ArrayList<>();
+        for (Friendship myfriend : myfriends) {
+            Users friend;
+            if (myfriend.getTo_user().equals(me)) {
+                friend = myfriend.getFrom_user();
+            } else {
+                friend = myfriend.getTo_user();
+            }
+
+            // 당일 작성한 회고 찾기
+            Optional<Memoir> optionalMemoir = memoirRepository.findByCreatedAt(friend.getId(), date);
+            Boolean memoirStatus = optionalMemoir.isPresent();
+            Long memoirId = optionalMemoir.map(Memoir::getId).orElse(0L);
+
+            // FriendshipDto 생성
+            FriendshipDto friendshipDto = FriendshipDto.builder()
+                    .friend_nickname(friend.getNickname())
+                    .memoir_status(memoirStatus)
+                    .memoir_id(memoirId)
+                    .build();
+            myfriendsInfo.add(friendshipDto);
+        }
+        return myfriendsInfo;
     }
 
 }

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -69,7 +69,7 @@ public class FriendService {
         Users friend = optionalFriend.get();
 
         //Check friendship already existing
-        Optional<Friendship> existingFriendship = friendshipRepository.findByToUserAndFromUser(users.getId(), friend.getId());
+        Optional<Friendship> existingFriendship = friendshipRepository.checkExistingFriendship(users.getId(), friend.getId());
         if (existingFriendship.isPresent()) {
             return ApiResponse.failure(Error.FRIENDSHIP_ALREADY_EXIST);
         }

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -65,9 +65,14 @@ public class FriendService {
         //Checking friend is existed
         Optional<Users> optionalFriend = usersRepository.findByNickname(requestDto.getNickname());
         if(optionalFriend.isEmpty())
-            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+            return ApiResponse.failure(Error.FRIEND_NICKNAME_NOT_FOUND);
         Users friend = optionalFriend.get();
 
+        //Check friendship already existing
+        Optional<Friendship> existingFriendship = friendshipRepository.findByToUserAndFromUser(users.getId(), friend.getId());
+        if (existingFriendship.isPresent()) {
+            return ApiResponse.failure(Error.FRIENDSHIP_ALREADY_EXIST);
+        }
         //Create Friendship
         Friendship newFriendship = requestDto.toEntity(users,friend);
         friendshipRepository.save(newFriendship);

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -108,7 +108,7 @@ public class MyPageService {
     }
 
     @Transactional
-    public ApiResponse<?> acceptFriend(MypageFriendUpdateRequestDto requestDto){
+    public ApiResponse<?> updateFriend(MypageFriendUpdateRequestDto requestDto){
         //Checking user
         Optional<Users> optionalUsers = usersRepository.findById(1L);
         if(optionalUsers.isEmpty())

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -116,16 +116,17 @@ public class MyPageService {
         Users users = optionalUsers.get();
         log.info("유저 이름 -> {}", users.getNickname());
 
-        //Checking friend is existed
-        Optional<Users> optionalFriend = usersRepository.findByNickname(requestDto.getNickname());
-        if(optionalFriend.isEmpty())
-            return ApiResponse.failure(Error.FRIEND_NICKNAME_NOT_FOUND);
-        Users friend = optionalFriend.get();
-        log.info("친구 이름 -> {}", users.getNickname());
-
-        Friendship friendship = friendshipRepository.findByUserIds(users.getId(), friend.getId());
-        if(friendship == null)
+        //Find Friendship
+        Optional<Friendship> optionalFriendship = friendshipRepository.findById(requestDto.getFriendship_id());
+        if(optionalFriendship.isEmpty())
             return ApiResponse.failure(Error.FRIENDSHIP_NOT_FOUND);
+        Friendship friendship = optionalFriendship.get();
+
+        //Check whether request nickname and friendship's from user nickname is matched
+        if(!friendship.getFrom_user().getNickname().equals(requestDto.getNickname()))
+            return ApiResponse.failure(Error.NOT_MATCHED_NICKNAME);
+
+        //Update Friendship
         friendship.updateStatus(requestDto.getFriendshipStatus());
 
         return ApiResponse.success(Success.UPDATE_FRIEND_SUCCESS, Map.of("nowStatus", friendship.getFriendshipStatus()));

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -182,6 +182,7 @@ public class MyPageService {
     private MyWaiting buildMyWaiting(Friendship friendship, Users me) {
         Users friend = getFriend(friendship, me);
         return MyWaiting.builder()
+                .friendship_id(friendship.getId())
                 .nickname(friend.getNickname())
                 .friendshipStatus(friendship.getFriendshipStatus())
                 .introduction(friend.getIntroduction())
@@ -191,6 +192,7 @@ public class MyPageService {
     private MyFriend buildMyFriend(Friendship friendship, Users me) {
         Users friend = getFriend(friendship, me);
         return MyFriend.builder()
+                .friendship_id(friendship.getId())
                 .nickname(friend.getNickname())
                 .friendshipStatus(friendship.getFriendshipStatus())
                 .introduction(friend.getIntroduction())

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -5,11 +5,13 @@ import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
 import floud.demo.domain.Friendship;
 import floud.demo.domain.Goal;
-import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
 import floud.demo.domain.enums.FriendshipStatus;
-import floud.demo.dto.friendship.FriendshipDto;
 import floud.demo.dto.mypage.*;
+import floud.demo.dto.mypage.dto.MyFriend;
+import floud.demo.dto.mypage.dto.MyGoal;
+import floud.demo.dto.mypage.dto.MyWaiting;
+import floud.demo.dto.mypage.dto.UpdateGoal;
 import floud.demo.repository.FriendshipRepository;
 import floud.demo.repository.GoalRepository;
 import floud.demo.repository.UsersRepository;
@@ -18,8 +20,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -130,6 +130,33 @@ public class MyPageService {
         friendship.updateStatus(requestDto.getFriendshipStatus());
 
         return ApiResponse.success(Success.UPDATE_FRIEND_SUCCESS, Map.of("nowStatus", friendship.getFriendshipStatus()));
+    }
+
+    @Transactional
+    public ApiResponse<?> deleteFriend(Long friendship_id){
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
+
+        //Find Friendship
+        Optional<Friendship> optionalFriendship = friendshipRepository.findById(friendship_id);
+        if(optionalFriendship.isEmpty())
+            return ApiResponse.failure(Error.FRIENDSHIP_NOT_FOUND);
+        Friendship friendship = optionalFriendship.get();
+
+        //Update Friendship
+        friendship.updateStatus(FriendshipStatus.REJECT);
+
+        return ApiResponse.success(Success.DELETE_FRIEND_SUCCESS, MypageFriendDeleteResponseDto.builder()
+                .friendship_id(friendship_id)
+                .to_user(friendship.getTo_user().getNickname())
+                .from_user(friendship.getFrom_user().getNickname())
+                .friendshipStatus(friendship.getFriendshipStatus())
+                .build());
+
     }
 
     public List<MyGoal> setGoalList(Long users_id){

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -93,7 +93,7 @@ public class MyPageService {
      * 친구 관리
      **/
     @Transactional
-    public ApiResponse getFriendList(){
+    public ApiResponse<?> getFriendList(){
         //Checking user
         Optional<Users> optionalUsers = usersRepository.findById(1L);
         if(optionalUsers.isEmpty())
@@ -107,7 +107,27 @@ public class MyPageService {
         return ApiResponse.success(Success.GET_FRIEND_LIST_SUCCESS,responseDto);
     }
 
+    @Transactional
+    public ApiResponse<?> acceptFriend(MypageFriendUpdateRequestDto requestDto){
+        //Checking user
+        Optional<Users> optionalUsers = usersRepository.findById(1L);
+        if(optionalUsers.isEmpty())
+            return ApiResponse.failure(Error.USERS_NOT_FOUND);
+        Users users = optionalUsers.get();
+        log.info("유저 이름 -> {}", users.getNickname());
 
+        //Checking friend is existed
+        Optional<Users> optionalFriend = usersRepository.findByNickname(requestDto.getNickname());
+        if(optionalFriend.isEmpty())
+            return ApiResponse.failure(Error.FRIEND_NICKNAME_NOT_FOUND);
+        Users friend = optionalFriend.get();
+        log.info("친구 이름 -> {}", users.getNickname());
+
+        Friendship friendship = friendshipRepository.findByUserIds(users.getId(), friend.getId());
+        friendship.updateStatus(requestDto.getFriendshipStatus());
+
+        return ApiResponse.success(Success.UPDATE_FRIEND_SUCCESS, Map.of("nowStatus", friendship.getFriendshipStatus()));
+    }
 
     public List<MyGoal> setGoalList(Long users_id){
         List<Goal> goals = goalRepository.findAllByUserId(users_id);

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -124,6 +124,8 @@ public class MyPageService {
         log.info("친구 이름 -> {}", users.getNickname());
 
         Friendship friendship = friendshipRepository.findByUserIds(users.getId(), friend.getId());
+        if(friendship == null)
+            return ApiResponse.failure(Error.FRIENDSHIP_NOT_FOUND);
         friendship.updateStatus(requestDto.getFriendshipStatus());
 
         return ApiResponse.success(Success.UPDATE_FRIEND_SUCCESS, Map.of("nowStatus", friendship.getFriendshipStatus()));

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -27,6 +27,11 @@ import java.util.stream.Collectors;
 public class MyPageService {
     private final UsersRepository usersRepository;
     private final GoalRepository goalRepository;
+
+
+    /**
+     * 내 정보
+     **/
     @Transactional
     public ApiResponse<?> getMypage(){
         //Checking user
@@ -78,6 +83,17 @@ public class MyPageService {
                 .goalList(updatedGoalList)
                 .build());
     }
+
+    /**
+     * 친구 관리
+     **/
+    @Transactional
+    public ApiResponse getFriendList(){
+
+        return ApiResponse.success(Success.GET_FRIEND_LIST_SUCCESS);
+    }
+
+
 
     public List<MyGoal> setGoalList(Long users_id){
         List<Goal> goals = goalRepository.findAllByUserId(users_id);


### PR DESCRIPTION
`/api/mypage/friend`
- 친구 조회 기능을 구현하였습니다.
- 친구 수락/거절 기능을 구현하였습니다.
- 친구 삭제 기능을 구현하였습니다.
- 유저 정보가 없는 경우, 친구의 정보가 없는 경우, 친구 관계가 정의되지 않은 경우, 
친구관계와 유저-친구의 이름이 매칭되지 않는 경우에 대해서 에러처리를 하였습니다. 


`Fix`
- 친구 등록시 to_user와 from_user가 반대로 저장되는 오류를 찾아
해결하였습니다.


`Todo`
- 소셜 로그인 후 토큰으로 유저 정보를 받아와야 합니다.
- 중복 코드를 리펙토링 해야 합니다.