### PR TITLE
feat: create healthcheck controller for load balancer

### DIFF
--- a/src/main/java/floud/demo/controller/HealthCheckController.java
+++ b/src/main/java/floud/demo/controller/HealthCheckController.java
@@ -1,0 +1,18 @@
+package floud.demo.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/health")
+public class HealthCheckController {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public String healthCheck() {
+        return "welcome floud";
+    }
+}


### PR DESCRIPTION
`/health`

- 로드밸런스 설정을 위해 health check 메소드를 구현했습니다.
- 해당 endpoint 접속시 200을 반환하도록 설정했습니다.


