### PR TITLE
Feat: 카카오 로그인 구현

### DIFF
--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -13,6 +13,7 @@ public enum Success {
 
     //200 SUCCESS
     GET_GOOGLE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "구글 로그인 성공"),
+    GET_KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "카카오 로그인 성공"),
 
     UPDATE_MEMOIR_SUCCESS(HttpStatus.OK , "성공적으로 회고를 수정하였습니다."),
     GET_MY_MEMOIR_SUCCESS(HttpStatus.OK , "나의 회고를 성공적으로 조회하였습니다."),

--- a/src/main/java/floud/demo/controller/AuthController.java
+++ b/src/main/java/floud/demo/controller/AuthController.java
@@ -33,5 +33,8 @@ public class AuthController {
         return authService.getKakaoAccessToken(code);
     }
 
-
+    @GetMapping("/kakao/login")
+    public RedirectView redirectToKakao() {
+        return authService.redirectToKakao();
+    }
 }

--- a/src/main/java/floud/demo/controller/AuthController.java
+++ b/src/main/java/floud/demo/controller/AuthController.java
@@ -23,9 +23,15 @@ public class AuthController {
         return authService.getGoogleAccessToken(code);
     }
 
-    @GetMapping("/login")
+    @GetMapping("/google/login")
     public RedirectView redirectToGoogle() {
         return authService.redirectToGoogle();
     }
+
+    @GetMapping("/callback/kakao")
+    public ApiResponse<?> successKakaooLogin(@RequestParam("code") String code) {
+        return authService.getKakaoAccessToken(code);
+    }
+
 
 }

--- a/src/main/java/floud/demo/service/AuthService.java
+++ b/src/main/java/floud/demo/service/AuthService.java
@@ -6,9 +6,10 @@ import floud.demo.common.response.Success;
 import floud.demo.dto.auth.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -20,6 +21,7 @@ import java.util.Map;
 public class AuthService {
 
     private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
 
     @Value("${oauth2.google.client-id}")
     private String GOOGLE_CLIENT_ID;
@@ -28,15 +30,26 @@ public class AuthService {
     @Value("${oauth2.google.redirect-uri}")
     private String GOOGLE_REDIRECT_URI;
     @Value("${oauth2.google.scope}")
-    private String scope;
+    private String googleScope;
 
-    private String baseUrl = "https://accounts.google.com/o/oauth2/v2/auth";
+    @Value("${oauth2.kakao.client-id}")
+    private String KAKAO_CLIENT_ID;
+    @Value("${oauth2.kakao.client-secret}")
+    private String KAKAO_CLIENT_SECRET;
+    @Value("${oauth2.kakao.redirect-uri}")
+    private String KAKAO_REDIRECT_URI;
+    @Value("${oauth2.kakao.scope}")
+    private String kakaoScope;
+
+
+    private String GOOGLE_BASE_URI = "https://accounts.google.com/o/oauth2/v2/auth";
+    private String KAKAO_BASE_URI = "https://kauth.kakao.com/oauth/authorize";
 
     public RedirectView redirectToGoogle() {
-        String url = baseUrl + "?client_id=" + GOOGLE_CLIENT_ID +
+        String url = GOOGLE_BASE_URI + "?client_id=" + GOOGLE_CLIENT_ID +
                 "&response_type=code" +
                 "&redirect_uri=" + GOOGLE_REDIRECT_URI +
-                "&scope=" + scope;
+                "&scope=" + googleScope;
         return new RedirectView(url);
     }
 
@@ -74,4 +87,51 @@ public class AuthService {
         }
     }
 
+    public RedirectView redirectToKakao() {
+        String url = KAKAO_BASE_URI + "?client_id=" + KAKAO_CLIENT_ID +
+                "&response_type=code" +
+                "&redirect_uri=" + KAKAO_REDIRECT_URI +
+                "&scope=" + kakaoScope;
+        System.out.println("url = " + url);
+        return new RedirectView(url);
+    }
+
+    public ApiResponse<?> getKakaoAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params= new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", KAKAO_CLIENT_ID);
+         params.add("client_secret", KAKAO_CLIENT_SECRET);
+        params.add("redirect_uri", KAKAO_REDIRECT_URI);
+        params.add("grant_type", "authorization_code");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> responseEntity = restTemplate.postForEntity(KAKAO_TOKEN_URL, request, String.class);
+            System.out.println("responseEntity = " + responseEntity);
+
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                ObjectMapper objectMapper = new ObjectMapper();
+                TokenResponseDto tokenResponseDto = objectMapper.readValue(responseEntity.getBody(), TokenResponseDto.class);
+
+                String accessToken = tokenResponseDto.getAccess_token();
+                String refreshToken = tokenResponseDto.getRefresh_token();
+
+                return ApiResponse.success(Success.GET_KAKAO_ACCESS_TOKEN_SUCCESS, TokenResponseDto.builder()
+                        .access_token(accessToken)
+                        .refresh_token(refreshToken)
+                        .build());
+            } else {
+                return null;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ApiResponse.failure(e);
+        }
+    }
 }


### PR DESCRIPTION
`/api/auth/kakao/login`

- 카카오 로그인을 통해 refresh_token, access_token 발급 로직을 구현했습니다.
- 로컬에서도 redirect view를 사용할 수 있도록 api를 구현했습니다.

`To Do`
- 토큰을 통해서 유저 정보를 가져오고 저장하는 로직이 필요합니다.