### PR TITLE
Feat: Friend 관련 api 추가

### DIFF
--- a/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
@@ -9,5 +9,7 @@ import java.util.List;
 @Builder
 public class FriendshipListResponseDto {
     private String my_nickname;
+    private Long totalFriendNum;
+    private Long totalPage;
     private List<FriendshipDto> friendshipList;
 }

--- a/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
+++ b/src/main/java/floud/demo/dto/friendship/FriendshipListResponseDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Builder
 public class FriendshipListResponseDto {
     private String my_nickname;
-    private Long totalFriendNum;
-    private Long totalPage;
+    private Integer totalFriendNum;
+    private Integer totalPage;
     private List<FriendshipDto> friendshipList;
 }

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -45,9 +45,12 @@ public class FriendService {
 
         //친구 정보 가져오기
         List<FriendshipDto> friendshipList = findFriendInfo(users, date);
+        Integer totalFriendNum = friendshipList.size();
 
         return ApiResponse.success(Success.GET_FRIEND_LIST_SUCCESS, FriendshipListResponseDto.builder()
                         .my_nickname(users.getNickname())
+                        .totalFriendNum(totalFriendNum)
+                        .totalPage()
                         .friendshipList(friendshipList)
                         .build());
     }

--- a/src/main/java/floud/demo/service/FriendService.java
+++ b/src/main/java/floud/demo/service/FriendService.java
@@ -50,7 +50,7 @@ public class FriendService {
         return ApiResponse.success(Success.GET_FRIEND_LIST_SUCCESS, FriendshipListResponseDto.builder()
                         .my_nickname(users.getNickname())
                         .totalFriendNum(totalFriendNum)
-                        .totalPage()
+                        .totalPage(totalFriendNum/8+1)
                         .friendshipList(friendshipList)
                         .build());
     }


### PR DESCRIPTION
`친구 조회`
- 친구 조회시 친구 수와 페이지 수 관련 데이터를 추가로 전달합니다. 

`친구 검색`
- 친구를 검색하는 api를 추가했습니다. 
- 본인의 닉네임 검색시 에러를 출력합니다. 