### PR TITLE
Refactor: 토큰으로 유저 정보 가져오기 로직 변경

### DIFF
--- a/src/main/java/floud/demo/controller/AuthController.java
+++ b/src/main/java/floud/demo/controller/AuthController.java
@@ -1,6 +1,9 @@
 package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Success;
+import floud.demo.dto.auth.SocialLoginDecodeResponseDto;
+import floud.demo.dto.auth.UsersResponseDto;
 import floud.demo.service.AuthService;
 import lombok.AllArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,6 +40,7 @@ public class AuthController {
 
     @GetMapping("/decode")
     public ApiResponse<?> getUserInfoByToken(@RequestHeader(value="Authorization") String authorizationHeader) {
-        return authService.getUserInfoByToken(authorizationHeader);
+        UsersResponseDto getUser = authService.getUserInfo(authorizationHeader);
+        return ApiResponse.success(Success.GET_USER_INFO_SUCCESS, getUser);
     }
 }

--- a/src/main/java/floud/demo/dto/auth/SocialLoginDecodeResponseDto.java
+++ b/src/main/java/floud/demo/dto/auth/SocialLoginDecodeResponseDto.java
@@ -1,0 +1,24 @@
+package floud.demo.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@RequiredArgsConstructor
+public class SocialLoginDecodeResponseDto {
+
+    @JsonProperty("sub")
+    private String social_id;
+    private String email;
+
+    @Builder
+    public SocialLoginDecodeResponseDto(String social_id, String email) {
+        this.social_id = social_id;
+        this.email = email;
+    }
+}

--- a/src/main/java/floud/demo/service/AuthService.java
+++ b/src/main/java/floud/demo/service/AuthService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Success;
 import floud.demo.domain.Users;
+import floud.demo.dto.auth.SocialLoginDecodeResponseDto;
 import floud.demo.dto.auth.TokenResponseDto;
 import floud.demo.dto.auth.UsersResponseDto;
 import floud.demo.repository.UsersRepository;
@@ -15,6 +16,7 @@ import jakarta.annotation.Resource;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ClassPathResource;
@@ -71,6 +73,9 @@ public class AuthService {
         return new RedirectView(url);
     }
 
+    /**
+     * 구글 로그인시 id_token 발급하는 메소드
+     */
 
     public ApiResponse<?> getGoogleAccessToken(String code) {
         RestTemplate restTemplate = new RestTemplate();
@@ -89,11 +94,15 @@ public class AuthService {
                 ObjectMapper objectMapper = new ObjectMapper();
                 TokenResponseDto tokenResponseDto = objectMapper.readValue(responseEntity.getBody(), TokenResponseDto.class);
 
-                String idToken = tokenResponseDto.getId_token();
+                String id_token = tokenResponseDto.getId_token();
                 String refreshToken = tokenResponseDto.getRefresh_token();
+                getUserInfo(id_token);
+//                if (getUser == null) { // 유저가 없을 때, 토큰 정보를 받아서 저장해야함
+//                    saveMemberInfo();
+//                }
 
                 return ApiResponse.success(Success.GET_GOOGLE_ACCESS_TOKEN_SUCCESS, TokenResponseDto.builder()
-                        .id_token(idToken)
+                        .id_token(id_token)
                         .refresh_token(refreshToken)
                         .build());
             } else {
@@ -105,6 +114,9 @@ public class AuthService {
         }
     }
 
+    /**
+     * 백엔드 테스트를 위한 redirect view api
+     */
     public RedirectView redirectToKakao() {
         String url = KAKAO_BASE_URI + "?client_id=" + KAKAO_CLIENT_ID +
                 "&response_type=code" +
@@ -113,6 +125,10 @@ public class AuthService {
         System.out.println("url = " + url);
         return new RedirectView(url);
     }
+
+    /**
+     * 카카오 로그인시 id_token 발급하는 메소드
+     */
 
     public ApiResponse<?> getKakaoAccessToken(String code) {
         RestTemplate restTemplate = new RestTemplate();
@@ -131,7 +147,6 @@ public class AuthService {
 
         try {
             ResponseEntity<String> responseEntity = restTemplate.postForEntity(KAKAO_TOKEN_URL, request, String.class);
-            System.out.println("responseEntity = " + responseEntity);
 
             if (responseEntity.getStatusCode() == HttpStatus.OK) {
                 ObjectMapper objectMapper = new ObjectMapper();
@@ -139,6 +154,8 @@ public class AuthService {
 
                 String id_token = tokenResponseDto.getId_token();
                 String refreshToken = tokenResponseDto.getRefresh_token();
+
+                getUserInfo(id_token);
 
                 return ApiResponse.success(Success.GET_KAKAO_ACCESS_TOKEN_SUCCESS, TokenResponseDto.builder()
                         .id_token(id_token)
@@ -153,25 +170,48 @@ public class AuthService {
         }
     }
 
-    public ApiResponse<?> getUserInfoByToken(String authorizationHeader) {
-
-        System.out.println("authorizationHeader = " + authorizationHeader);
+    public SocialLoginDecodeResponseDto getUserSocialInfo(String authorizationHeader) {
 
         String token = authorizationHeader.substring("Bearer ".length());
-        UsersResponseDto userinfo = decodeToken(token);
-        Users getUser = findUserBySocial_id(userinfo.getSocial_id());
-        System.out.println("getUser = " + getUser);
-        UsersResponseDto usersInfoResponse = userinfo.builder()
-                .users_id(getUser.getId())
-                .email(getUser.getEmail())
-                .social_id(getUser.getSocial_id())
-                .nickname(getUser.getNickname())
-                .build();
+        SocialLoginDecodeResponseDto socialUserinfo = decodeToken(token); // id_token으로 유저 정보를 가져옴 -> 1. social_id 2. email
+        if (socialUserinfo == null) return null;
 
-        return ApiResponse.success(Success.GET_USER_INFO_SUCCESS, usersInfoResponse);
+        return socialUserinfo.builder()
+                .email(socialUserinfo.getEmail())
+                .social_id(socialUserinfo.getSocial_id())
+                .build();
     }
 
-    public UsersResponseDto decodeToken(String token) {
+    public UsersResponseDto getUserInfo(String authorizationHeader) {
+
+        String token = authorizationHeader.substring("Bearer ".length());
+        SocialLoginDecodeResponseDto userinfo = decodeToken(token); // 1. 토큰 통해 social ID 가져옴
+        Users getUser = findUserBySocial_id(userinfo.getSocial_id()); // 2. 유저가 없으면 DB에 없다는 것임
+        Users newUser = new Users();
+        if (getUser == null) {
+            newUser.setEmail(userinfo.getEmail());
+            newUser.setSocial_id(userinfo.getSocial_id());
+            newUser.setNickname(generateUniqueNickname());
+            usersRepository.save(newUser);
+            return UsersResponseDto.builder()
+                    .users_id(newUser.getId())
+                    .nickname(newUser.getNickname())
+                    .email(newUser.getEmail())
+                    .social_id(newUser.getSocial_id())
+                    .build();
+        }
+        return UsersResponseDto.builder()
+                .users_id(getUser.getId())
+                .nickname(getUser.getNickname())
+                .email(getUser.getEmail())
+                .social_id(getUser.getSocial_id())
+                .build();
+    }
+
+    /**
+     * 해당 메소드는 토큰에서 유저 정보를 가져오는 것이다.
+     */
+    public SocialLoginDecodeResponseDto decodeToken(String token) {
         String decode = decryptBase64UrlToken(token.split("\\.")[1]);
         System.out.println("decode = " + decode);
         return transJsonToMemberInfoDto(decode);
@@ -182,12 +222,10 @@ public class AuthService {
         return new String(decode, StandardCharsets.UTF_8);
     }
 
-    public UsersResponseDto transJsonToMemberInfoDto(String json) {
+    public SocialLoginDecodeResponseDto transJsonToMemberInfoDto(String json) {
         try {
             ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            UsersResponseDto dto = mapper.readValue(json, UsersResponseDto.class);
-            System.out.println("UsersRespone로 변경= " + dto);
-            saveMemberInfo(dto);
+            SocialLoginDecodeResponseDto dto = mapper.readValue(json, SocialLoginDecodeResponseDto.class);
             return dto;
         } catch (JsonMappingException e) {
             throw new RuntimeException(e);
@@ -196,35 +234,9 @@ public class AuthService {
         }
     }
 
-    @Transactional
-    public void saveMemberInfo(UsersResponseDto dto) {
-        try {
-            Optional<Users> user = usersRepository.findBySocial_id(dto.getSocial_id());
-            System.out.println("멤버 조회");
-            System.out.println("OAuth ID: " + dto.getSocial_id());
-            System.out.println("member 존재 여부: " + user.isPresent());
-            processMember(user, dto);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
-    private void processMember(Optional<Users> users, UsersResponseDto dto) {
-        users.ifPresentOrElse(
-                existingUser -> {
-                    System.out.println("유저가 이미 존재합니다: " + existingUser);
-                },
-                () -> {
-                    Users newUser = dto.toEntity();
-                    newUser.setNickname(generateUniqueNickname()); // 랜덤 닉네임 생성 및 저장
-                    System.out.println("새 멤버 저장됨: " + newUser);
-                    usersRepository.save(newUser);
-                }
-        );
-    }
     public Users findUserBySocial_id(String social_id) {
-        return usersRepository.findBySocial_id(social_id)
-                .orElseThrow(() -> new EntityNotFoundException("Member not found"));
+        return usersRepository.findBySocial_id(social_id).orElse(null);
     }
 
     private List<String> loadWordsFromFile() throws IOException {


### PR DESCRIPTION
`/api/auth/decode`

`수정사항`
- 유저 첫 로그인시 DB에 정보 저장안되는 버그를 수정했습니다.
-> 첫 로그인시 유저정보 저장 및 id_token, refresh_token 발급 됨

`로그인시 Response image`

```
{
    "code":200,
    "success":true,
    "message":"구글 로그인 성공",
    "data": {
        "id_token":"eyJhbGciOiJSdwqs6dclw",
        "refresh_token":null}
    }
}
```



`유저 정보 조회시 Response image`
```
{
    "code": 200,
    "success": true,
    "message": "유저 정보를 불러왔습니다.",
    "data": {
        "users_id": 9,
        "email": "jobc31230@gmail.com",
        "nickname": "울고싶은미지586",
        "sub": "3373123905"
    }
}
```