### PR TITLE
Feat: refresh으로 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -14,6 +14,7 @@ public enum Success {
     //200 SUCCESS
     GET_GOOGLE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "구글 로그인 성공"),
     GET_KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "카카오 로그인 성공"),
+    GET_REISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "토큰 재발급 성공"),
 
     GET_USER_INFO_SUCCESS(HttpStatus.OK , "유저 정보를 불러왔습니다."),
 

--- a/src/main/java/floud/demo/controller/AuthController.java
+++ b/src/main/java/floud/demo/controller/AuthController.java
@@ -2,6 +2,7 @@ package floud.demo.controller;
 
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Success;
+import floud.demo.dto.auth.RefreshTokenResponseDto;
 import floud.demo.dto.auth.SocialLoginDecodeResponseDto;
 import floud.demo.dto.auth.UsersResponseDto;
 import floud.demo.service.AuthService;
@@ -42,5 +43,11 @@ public class AuthController {
     public ApiResponse<?> getUserInfoByToken(@RequestHeader(value="Authorization") String authorizationHeader) {
         UsersResponseDto getUser = authService.getUserInfo(authorizationHeader);
         return ApiResponse.success(Success.GET_USER_INFO_SUCCESS, getUser);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<?> getTokenByRefreshToken(@RequestParam("refresh_token") String refreshToken) {
+        RefreshTokenResponseDto result = authService.reissueTokenByRefresh(refreshToken);
+        return ApiResponse.success(Success.GET_REISSUE_ACCESS_TOKEN_SUCCESS,result);
     }
 }

--- a/src/main/java/floud/demo/controller/AuthController.java
+++ b/src/main/java/floud/demo/controller/AuthController.java
@@ -45,9 +45,15 @@ public class AuthController {
         return ApiResponse.success(Success.GET_USER_INFO_SUCCESS, getUser);
     }
 
-    @PostMapping("/refresh")
-    public ApiResponse<?> getTokenByRefreshToken(@RequestParam("refresh_token") String refreshToken) {
-        RefreshTokenResponseDto result = authService.reissueTokenByRefresh(refreshToken);
+    @PostMapping("/kakao/refresh")
+    public ApiResponse<?> getKakaoByRefreshToken(@RequestParam("refresh_token") String refreshToken) {
+        RefreshTokenResponseDto result = authService.reissueKakaoByRefresh(refreshToken);
+        return ApiResponse.success(Success.GET_REISSUE_ACCESS_TOKEN_SUCCESS,result);
+    }
+
+    @PostMapping("/google/refresh")
+    public ApiResponse<?> getGoogleByRefreshToken(@RequestParam("refresh_token") String refreshToken) {
+        RefreshTokenResponseDto result = authService.reissueGoogleByRefresh(refreshToken);
         return ApiResponse.success(Success.GET_REISSUE_ACCESS_TOKEN_SUCCESS,result);
     }
 }

--- a/src/main/java/floud/demo/dto/auth/RefreshTokenResponseDto.java
+++ b/src/main/java/floud/demo/dto/auth/RefreshTokenResponseDto.java
@@ -1,0 +1,22 @@
+package floud.demo.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class RefreshTokenResponseDto {
+
+    private String id_token;
+    private String refresh_token;
+
+    @Builder
+    public RefreshTokenResponseDto(String id_token, String refresh_token) {
+        this.id_token = id_token;
+        this.refresh_token = refresh_token;
+    }
+
+}

--- a/src/main/java/floud/demo/service/AuthService.java
+++ b/src/main/java/floud/demo/service/AuthService.java
@@ -252,7 +252,7 @@ public class AuthService {
         }
     }
 
-    public RefreshTokenResponseDto reissueTokenByRefresh(String refreshToken) {
+    public RefreshTokenResponseDto reissueKakaoByRefresh(String refreshToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
@@ -273,11 +273,36 @@ public class AuthService {
                 new ParameterizedTypeReference<Map<String, String>>() {}
         );
 
-        RefreshTokenResponseDto refreshTokenResponseDto = RefreshTokenResponseDto.builder()
+        return RefreshTokenResponseDto.builder()
                 .id_token(responseEntity.getBody().get("id_token"))
                 .refresh_token(responseEntity.getBody().get("refresh_token"))
                 .build();
-        return refreshTokenResponseDto;
+    }
 
+    public RefreshTokenResponseDto reissueGoogleByRefresh(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("refresh_token", refreshToken);
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", GOOGLE_CLIENT_ID);
+        params.add("client_secret", GOOGLE_CLIENT_SECRET);
+
+        // 헤더와 파라미터를 합쳐서 요청 엔터티 생성
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map<String, String>> responseEntity = new RestTemplate().exchange(
+                GOOGLE_TOKEN_URL,
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<Map<String, String>>() {}
+        );
+
+        return RefreshTokenResponseDto.builder()
+                .id_token(responseEntity.getBody().get("id_token"))
+                .refresh_token(responseEntity.getBody().get("refresh_token"))
+                .build();
     }
 }

--- a/src/main/java/floud/demo/service/AuthService.java
+++ b/src/main/java/floud/demo/service/AuthService.java
@@ -7,18 +7,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Success;
 import floud.demo.domain.Users;
+import floud.demo.dto.auth.RefreshTokenResponseDto;
 import floud.demo.dto.auth.SocialLoginDecodeResponseDto;
 import floud.demo.dto.auth.TokenResponseDto;
 import floud.demo.dto.auth.UsersResponseDto;
 import floud.demo.repository.UsersRepository;
 import io.jsonwebtoken.io.Decoders;
-import jakarta.annotation.Resource;
-import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
@@ -97,9 +95,6 @@ public class AuthService {
                 String id_token = tokenResponseDto.getId_token();
                 String refreshToken = tokenResponseDto.getRefresh_token();
                 getUserInfo(id_token);
-//                if (getUser == null) { // 유저가 없을 때, 토큰 정보를 받아서 저장해야함
-//                    saveMemberInfo();
-//                }
 
                 return ApiResponse.success(Success.GET_GOOGLE_ACCESS_TOKEN_SUCCESS, TokenResponseDto.builder()
                         .id_token(id_token)
@@ -255,5 +250,34 @@ public class AuthService {
             e.printStackTrace();
             return null;
         }
+    }
+
+    public RefreshTokenResponseDto reissueTokenByRefresh(String refreshToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("refresh_token", refreshToken);
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", KAKAO_CLIENT_ID);
+        params.add("client_secret", KAKAO_CLIENT_SECRET);
+
+        // 헤더와 파라미터를 합쳐서 요청 엔터티 생성
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        ResponseEntity<Map<String, String>> responseEntity = new RestTemplate().exchange(
+                KAKAO_TOKEN_URL,
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<Map<String, String>>() {}
+        );
+
+        RefreshTokenResponseDto refreshTokenResponseDto = RefreshTokenResponseDto.builder()
+                .id_token(responseEntity.getBody().get("id_token"))
+                .refresh_token(responseEntity.getBody().get("refresh_token"))
+                .build();
+        return refreshTokenResponseDto;
+
     }
 }


### PR DESCRIPTION
`/kakao/refresh` : 카카오 로그인 토큰 재발급
`/google/refresh` : 구글 로그인 토큰 재발급

- refresh token을 통해 재발급이 가능하도록 수정했습니다.
- 각 사의 정책에 따라 refresh token 발급 주기가 상이합니다.