### PR TITLE
Feat: 레디스에 refresh token 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -12,6 +12,7 @@ public enum Error {
     ERROR(HttpStatus.BAD_REQUEST, "Request processing failed"),
 
     // 404 NOT FOUND
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰 정보를 찾을 수 없습니다."),
     USERS_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     FRIEND_NICKNAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 닉네임의 회원을 찾을 수 없습니다."),
     FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 친구 관계를 찾을 수 없습니다."),

--- a/src/main/java/floud/demo/common/response/Success.java
+++ b/src/main/java/floud/demo/common/response/Success.java
@@ -15,6 +15,8 @@ public enum Success {
     GET_GOOGLE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "구글 로그인 성공"),
     GET_KAKAO_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "카카오 로그인 성공"),
     GET_REISSUE_ACCESS_TOKEN_SUCCESS(HttpStatus.OK , "토큰 재발급 성공"),
+    GET_REFRESH_TOKEN_SUCCESS(HttpStatus.OK , "리프레시 토큰을 성공적으로 가져왔습니다."),
+
 
     GET_USER_INFO_SUCCESS(HttpStatus.OK , "유저 정보를 불러왔습니다."),
 
@@ -36,8 +38,7 @@ public enum Success {
     CREATE_MEMOIR_SUCCESS(HttpStatus.CREATED, "성공적으로 회고를 등록하였습니다."),
     UPDATE_MYPAGE_SUCCESS(HttpStatus.CREATED , "마이페이지를 성공적으로 수정하였습니다."),
     REQUEST_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 요청을 성공적으로 보내었습니다."),
-    UPDATE_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 상태를 성공적으로 변경하였습니다."),
-    ;
+    UPDATE_FRIEND_SUCCESS(HttpStatus.CREATED , "친구 상태를 성공적으로 변경하였습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/floud/demo/controller/RedisController.java
+++ b/src/main/java/floud/demo/controller/RedisController.java
@@ -1,0 +1,34 @@
+package floud.demo.controller;
+
+import floud.demo.common.response.ApiResponse;
+import floud.demo.common.response.Error;
+import floud.demo.common.response.Success;
+import floud.demo.dto.auth.RedisTokenResponseDto;
+import floud.demo.service.RedisService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class RedisController {
+
+    @Autowired
+    private RedisService redisService;
+
+    @GetMapping("/get-refresh-token")
+    public ApiResponse<?> getRefreshToken(@RequestParam Long userId) {
+        String refreshToken = redisService.getRefreshToken(userId);
+        RedisTokenResponseDto getRefreshToken = RedisTokenResponseDto.builder()
+                .refresh_token(refreshToken)
+                .build();
+
+        if (refreshToken != null) {
+            return ApiResponse.success(Success.GET_REFRESH_TOKEN_SUCCESS, getRefreshToken);
+        } else {
+            return ApiResponse.failure(Error.REFRESH_TOKEN_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/floud/demo/dto/auth/RedisTokenResponseDto.java
+++ b/src/main/java/floud/demo/dto/auth/RedisTokenResponseDto.java
@@ -1,0 +1,18 @@
+package floud.demo.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class RedisTokenResponseDto {
+    private String refresh_token;
+
+    @Builder
+    public RedisTokenResponseDto(String refresh_token) {
+        this.refresh_token = refresh_token;
+    }
+}

--- a/src/main/java/floud/demo/service/RedisService.java
+++ b/src/main/java/floud/demo/service/RedisService.java
@@ -1,0 +1,24 @@
+package floud.demo.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisService {
+    private static final String REDIS_KEY_PREFIX = "refresh_token:";
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        String key = REDIS_KEY_PREFIX + userId;
+        redisTemplate.opsForValue().set(key, refreshToken);
+    }
+
+    public String getRefreshToken(Long userId) {
+        String key = REDIS_KEY_PREFIX + userId;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+}


### PR DESCRIPTION
`/api/get-refresh-token?userId=`

- 소셜 로그인 진행시 refresh token이 해당 users_id 값에 저장되도록 기능을 추가했습니다.

`TO DO`
- 현재 로직이 보안상 불안정해 수정이 필요합니다.

`response`

```
{
    "code": 200,
    "success": true,
    "message": "리프레시 토큰을 성공적으로 가져왔습니다.",
    "data": {
        "refresh_token": "wAfTeytTtQNf-rbbRq1eNnYX9-lPKF0C-icKKiVRAAABjhRuA3ukJA3lYdtGWQ"
    }
}
```
