### PR TITLE
Feat: 알람 테이블 생성

### DIFF
--- a/src/main/java/floud/demo/domain/Alarm.java
+++ b/src/main/java/floud/demo/domain/Alarm.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class Alarm extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "notification_id")
+    @Column(name = "alarm_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/floud/demo/domain/Alarm.java
+++ b/src/main/java/floud/demo/domain/Alarm.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Entity
-public class Notification extends BaseTimeEntity {
+public class Alarm extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "notification_id")
@@ -23,7 +23,7 @@ public class Notification extends BaseTimeEntity {
     private String message;
 
     @Builder
-    public Notification(Long id, Users users, String message){
+    public Alarm(Long id, Users users, String message){
         this.id = id;
         this.users = users;
         this.message = message;

--- a/src/main/java/floud/demo/domain/Alarm.java
+++ b/src/main/java/floud/demo/domain/Alarm.java
@@ -20,12 +20,15 @@ public class Alarm extends BaseTimeEntity {
     private Users users;
 
     @Column(nullable = false)
+    private String nickname;
+
+    @Column(nullable = false)
     private String message;
 
     @Builder
-    public Alarm(Long id, Users users, String message){
-        this.id = id;
+    public Alarm(Users users, String nickname, String message){
         this.users = users;
+        this.nickname = nickname;
         this.message = message;
     }
 }

--- a/src/main/java/floud/demo/domain/Notification.java
+++ b/src/main/java/floud/demo/domain/Notification.java
@@ -1,0 +1,31 @@
+package floud.demo.domain;
+
+import floud.demo.common.domain.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Entity
+public class Notification extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id")
+    private Users users;
+
+    @Column(nullable = false)
+    private String message;
+
+    @Builder
+    public Notification(Long id, Users users, String message){
+        this.id = id;
+        this.users = users;
+        this.message = message;
+    }
+}

--- a/src/main/java/floud/demo/repository/AlarmRepository.java
+++ b/src/main/java/floud/demo/repository/AlarmRepository.java
@@ -1,0 +1,7 @@
+package floud.demo.repository;
+
+import floud.demo.domain.Alarm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+}

--- a/src/main/java/floud/demo/service/FriendshipService.java
+++ b/src/main/java/floud/demo/service/FriendshipService.java
@@ -3,6 +3,7 @@ package floud.demo.service;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Alarm;
 import floud.demo.domain.Friendship;
 import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
@@ -11,6 +12,7 @@ import floud.demo.dto.friendship.FriendshipCreateRequestDto;
 import floud.demo.dto.friendship.FriendshipDto;
 import floud.demo.dto.friendship.FriendshipListResponseDto;
 import floud.demo.dto.memoir.OneMemoirResponseDto;
+import floud.demo.repository.AlarmRepository;
 import floud.demo.repository.FriendshipRepository;
 import floud.demo.repository.MemoirRepository;
 import floud.demo.repository.UsersRepository;
@@ -34,6 +36,7 @@ public class FriendshipService {
     private final UsersRepository usersRepository;
     private final MemoirRepository memoirRepository;
     private final FriendshipRepository friendshipRepository;
+    private final AlarmRepository alarmRepository;
 
 
     @Transactional
@@ -87,9 +90,13 @@ public class FriendshipService {
         if (existingFriendship.isPresent()) {
             return ApiResponse.failure(Error.FRIENDSHIP_ALREADY_EXIST);
         }
+
         //Create Friendship
         Friendship newFriendship = requestDto.toEntity(friend, users);
         friendshipRepository.save(newFriendship);
+
+        //Create Alarm
+        createAlarm(users, friend);
 
         return ApiResponse.success(Success.REQUEST_FRIEND_SUCCESS, Map.of("friendship_id", newFriendship.getId()));
     }
@@ -115,6 +122,11 @@ public class FriendshipService {
                 .created_at(memoir.getCreated_at())
                 .build());
 
+    }
+
+    private void createAlarm(Users from_user, Users to_user){
+        String message = "친구 신청이 왔습니다.";
+        alarmRepository.save(new Alarm(to_user, from_user.getNickname(), message));
     }
 
     public List<FriendshipDto> findFriendInfo(Users me, LocalDate date){

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -130,8 +130,7 @@ public class MemoirService {
         List<Users> friendList = findMyFriendList(user);
         for (Users friend : friendList) {
             String message = "최근 회고를 작성했습니다.";
-            Alarm alarm = new Alarm(friend, user.getNickname(), message);
-            alarmRepository.save(alarm);
+            alarmRepository.save(new Alarm(friend, user.getNickname(), message));
         }
     }
 

--- a/src/main/java/floud/demo/service/MemoirService.java
+++ b/src/main/java/floud/demo/service/MemoirService.java
@@ -3,9 +3,14 @@ package floud.demo.service;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Alarm;
+import floud.demo.domain.Friendship;
 import floud.demo.domain.Memoir;
 import floud.demo.domain.Users;
+import floud.demo.dto.friendship.FriendshipDto;
 import floud.demo.dto.memoir.*;
+import floud.demo.repository.AlarmRepository;
+import floud.demo.repository.FriendshipRepository;
 import floud.demo.repository.MemoirRepository;
 import floud.demo.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,6 +31,8 @@ import java.util.stream.Collectors;
 public class MemoirService {
     private final AuthService authService;
     private final MemoirRepository memoirRepository;
+    private final AlarmRepository alarmRepository;
+    private final FriendshipRepository friendshipRepository;
 
     @Transactional
     public ApiResponse<?> createMemoir(String authorizationHeader, MemoirCreateRequestDto memoirCreateRequestDto){
@@ -39,6 +47,10 @@ public class MemoirService {
         //Create Memoir
         Memoir newMemoir = memoirCreateRequestDto.toEntity(users);
         memoirRepository.save(newMemoir);
+
+        //Create Alarm
+        createAlarm(users);
+
         return ApiResponse.success(Success.CREATE_MEMOIR_SUCCESS, Map.of("memoir_id", newMemoir.getId()));
     }
 
@@ -113,4 +125,29 @@ public class MemoirService {
         return  ApiResponse.success(Success.GET_MULTIPLE_MEMOIR_SUCCESS, responseDto);
 
     }
+
+    private void createAlarm(Users user){
+        List<Users> friendList = findMyFriendList(user);
+        for (Users friend : friendList) {
+            String message = "최근 회고를 작성했습니다.";
+            Alarm alarm = new Alarm(friend, user.getNickname(), message);
+            alarmRepository.save(alarm);
+        }
+    }
+
+    private List<Users> findMyFriendList(Users me){
+        List<Friendship> myfriendship = friendshipRepository.findAllByUsersId(me.getId());
+        List<Users> friendList = new ArrayList<>();
+        for (Friendship myfriend : myfriendship) {
+            Users friend;
+            if (myfriend.getTo_user().equals(me)) {
+                friend = myfriend.getFrom_user();
+            } else {
+                friend = myfriend.getTo_user();
+            }
+            friendList.add(friend);
+        }
+        return friendList;
+    }
+
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -3,6 +3,7 @@ package floud.demo.service;
 import floud.demo.common.response.ApiResponse;
 import floud.demo.common.response.Error;
 import floud.demo.common.response.Success;
+import floud.demo.domain.Alarm;
 import floud.demo.domain.Friendship;
 import floud.demo.domain.Goal;
 import floud.demo.domain.Users;
@@ -12,6 +13,7 @@ import floud.demo.dto.mypage.dto.MyFriend;
 import floud.demo.dto.mypage.dto.MyGoal;
 import floud.demo.dto.mypage.dto.MyWaiting;
 import floud.demo.dto.mypage.dto.UpdateGoal;
+import floud.demo.repository.AlarmRepository;
 import floud.demo.repository.FriendshipRepository;
 import floud.demo.repository.GoalRepository;
 import floud.demo.repository.UsersRepository;
@@ -33,6 +35,7 @@ public class MyPageService {
     private final UsersRepository usersRepository;
     private final GoalRepository goalRepository;
     private final FriendshipRepository friendshipRepository;
+    private final AlarmRepository alarmRepository;
 
 
     /**
@@ -108,13 +111,15 @@ public class MyPageService {
         Friendship friendship = optionalFriendship.get();
 
         //Check whether request nickname and friendship's from user nickname is matched
-        if(!friendship.getFrom_user().getNickname().equals(requestDto.getNickname()))
-            return ApiResponse.failure(Error.NOT_MATCHED_NICKNAME);
-        if(!friendship.getTo_user().getNickname().equals(users.getNickname()))
+        if(!friendship.getFrom_user().getNickname().equals(requestDto.getNickname())
+            && !friendship.getTo_user().getNickname().equals(users.getNickname()))
             return ApiResponse.failure(Error.NOT_MATCHED_NICKNAME);
 
         //Update Friendship
         friendship.updateStatus(requestDto.getFriendshipStatus());
+
+        //Create Alarm
+        createAlarm(friendship.getFrom_user(), users);
 
         return ApiResponse.success(Success.UPDATE_FRIEND_SUCCESS, Map.of("nowStatus", friendship.getFriendshipStatus()));
     }
@@ -224,4 +229,10 @@ public class MyPageService {
             return friendship.getTo_user();
         }
     }
+
+    private void createAlarm(Users from_user, Users to_user){
+        String message = "친구 신청이 수락되었습니다.";
+        alarmRepository.save(new Alarm(from_user, to_user.getNickname(), message));
+    }
+
 }


### PR DESCRIPTION
`Alarm`
![image](https://github.com/FlouD-2024/FlouD-back/assets/90603399/383a2053-be57-4ef8-95ff-7d177233aab0)

- nickname은 알람을 생성한 사람의 닉네임
- 메세지는 세종류
1. 최근 회고를 작성하였습니다.
2. 친구 신청이 왔습니다.
3. 친구 신청이 수락되었습니다.

➡️ 따라서 알람 조회시, 해당 유저의 알람 검색해서 nickname, message, + created_at만 그대로 리턴하면 됩니다!


`Todo` 
30개 이상 저장되었을 때 삭제되는 로직이 없음
- 해당로직 추가하거나
- 조회시 30개만 조회하거나

