### PR TITLE
Feat: 유저 정보 업데이트와 친구 삭제시 발생하는 로직 에러 해결 && 친구관계 자동 삭제 구현

### DIFF
--- a/src/main/java/floud/demo/common/response/Error.java
+++ b/src/main/java/floud/demo/common/response/Error.java
@@ -22,6 +22,7 @@ public enum Error {
     NOT_BE_FRIEND_MYSELF(HttpStatus.CONFLICT, "본인과는 친구가 될 수 없습니다."),
     MEMOIR_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 오늘의 회고를 작성하였습니다."),
     FRIENDSHIP_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 친구 관계가 존재합니다."),
+    NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "해당 닉네임을 가진 유저가 이미 존재합니다. 닉네임 중복 체크를 해주세요."),
     NOT_MATCHED_NICKNAME(HttpStatus.CONFLICT, "친구 관계 정보가 일치하지 않습니다."),
 
     // 500 INTERNAL SERVER ERROR

--- a/src/main/java/floud/demo/domain/Users.java
+++ b/src/main/java/floud/demo/domain/Users.java
@@ -2,6 +2,7 @@ package floud.demo.domain;
 
 import floud.demo.common.domain.BaseTimeEntity;
 import floud.demo.domain.Memoir;
+import floud.demo.dto.mypage.MypageUpdateRequestDto;
 import jakarta.persistence.*;
 
 import lombok.*;
@@ -51,7 +52,8 @@ public class Users extends BaseTimeEntity {
         this.memoirList = memoirList;
     }
 
-    public void updateIntroduction(String introduction){
-        this.introduction = introduction;
+    public void updateUserInfo(MypageUpdateRequestDto requestDto){
+        this.nickname = requestDto.getNickname();
+        this.introduction = requestDto.getIntroduction();
     }
 }

--- a/src/main/java/floud/demo/repository/FriendshipRepository.java
+++ b/src/main/java/floud/demo/repository/FriendshipRepository.java
@@ -15,7 +15,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findAllByUsersId(Long users_id);
 
     //현재 친구 관계가 있는 지 확인
-    @Query(value = "SELECT * FROM Friendship f " +
+    @Query(value = "SELECT * FROM friendship f " +
             "WHERE (f.to_user = :toUserId AND f.from_user = :fromUserId) " +
             "OR (f.to_user = :fromUserId AND f.from_user = :toUserId)",  nativeQuery = true)
     Optional<Friendship> checkExistingFriendship(Long toUserId, Long fromUserId);
@@ -26,5 +26,9 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<Friendship> findAllByWaitingToUser(Long users_id);
 
     Optional<Friendship> findById(Long id);
+
+    //친구 거절/삭제한 친구 관계들
+    @Query(value = "SELECT * FROM friendship f WHERE f.friendship_status = 'REJECT'", nativeQuery = true)
+    List<Friendship> findAllRejectStatus();
 
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -58,8 +58,7 @@ public class MyPageService {
 
     @Transactional
     public ApiResponse<?> checkDuplicatedName(String authorizationHeader, String nickname){
-        boolean isDuplicated = usersRepository.existsByNickname(nickname);
-        return ApiResponse.success(Success.CHECK_NICKNAME_DUPLICATED, Map.of("isDuplicated", isDuplicated));
+        return ApiResponse.success(Success.CHECK_NICKNAME_DUPLICATED, Map.of("isDuplicated", checkNicknameDuplicated(nickname)));
     }
 
     @Transactional
@@ -153,7 +152,7 @@ public class MyPageService {
 
     }
 
-    public List<MyGoal> setGoalList(Long users_id){
+    private List<MyGoal> setGoalList(Long users_id){
         List<Goal> goals = goalRepository.findAllByUserId(users_id);
         return goals.stream()
                 .map(goal -> MyGoal.builder()
@@ -164,7 +163,7 @@ public class MyPageService {
                 .collect(Collectors.toList());
     }
 
-    public void updateGoal(Users users, List<UpdateGoal> requestDtoGoalList){
+    private void updateGoal(Users users, List<UpdateGoal> requestDtoGoalList){
         List<Goal> goals = goalRepository.findAllByUserId(users.getId());
 
         // Delete all existing goals
@@ -181,6 +180,10 @@ public class MyPageService {
             Goal newGoal = goal.toEntity(users);
             goalRepository.save(newGoal);
         }
+    }
+
+    private boolean checkNicknameDuplicated(String nickname){
+        return usersRepository.existsByNickname(nickname);
     }
 
     public MypageFriendListResponseDto findFriends(Users me){
@@ -234,5 +237,6 @@ public class MyPageService {
         String message = "친구 신청이 수락되었습니다.";
         alarmRepository.save(new Alarm(from_user, to_user.getNickname(), message));
     }
+
 
 }

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -66,7 +66,11 @@ public class MyPageService {
         //Get user
         Users users = authService.findUserByToken(authorizationHeader);
 
-        //Update Introduction
+        //Check Nickname Duplicated
+        if(checkNicknameDuplicated(requestDto.getNickname()))
+                return ApiResponse.failure(Error.NICKNAME_ALREADY_EXIST);
+
+        //Update User info
         users.updateUserInfo(requestDto);
         usersRepository.save(users);
 

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -68,7 +68,7 @@ public class MyPageService {
         Users users = authService.findUserByToken(authorizationHeader);
 
         //Update Introduction
-        users.updateIntroduction(requestDto.getIntroduction());
+        users.updateUserInfo(requestDto);
         usersRepository.save(users);
 
         //Update Goals

--- a/src/main/java/floud/demo/service/MyPageService.java
+++ b/src/main/java/floud/demo/service/MyPageService.java
@@ -141,7 +141,7 @@ public class MyPageService {
         //Check is user's friendship
         Users to_user = friendship.getTo_user();
         Users from_user = friendship.getFrom_user();
-        if(!to_user.equals(users)||!from_user.equals(users))
+        if(!to_user.equals(users)&&!from_user.equals(users))
             return ApiResponse.failure(Error.NOT_MATCHED_NICKNAME);
 
         //Update Friendship

--- a/src/main/java/floud/demo/service/SchedulerService.java
+++ b/src/main/java/floud/demo/service/SchedulerService.java
@@ -1,0 +1,26 @@
+package floud.demo.service;
+
+import floud.demo.domain.Friendship;
+import floud.demo.repository.FriendshipRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulerService {
+
+    private final FriendshipRepository friendshipRepository;
+
+    @Transactional
+    @Async
+    @Scheduled(cron = "0 0 0 * * *")
+    public void autoFriendshipDelete() {
+        List<Friendship> friendshipList = friendshipRepository.findAllRejectStatus();
+        friendshipRepository.deleteAll(friendshipList);
+    }
+}


### PR DESCRIPTION
`유저 정보`
- 닉네임 업데이트 안되는 에러 해결
- 닉네임 업데이트 하기 전에 닉네임 중복 체크
- 이미 존재하는 닉네임일시 (==중복 확인을 진행하지 않은 닉네임으로 수정 요청시)
409 에러

`친구 관계`
- 친구 삭제 시 '나의 친구 관계 확인' 관련 로직에서 논리적 오류 해결
- 친구 거절/삭제 결과 친구 관계 상태(FriendshipStatus)가 REJECT된 친구관계들을
매일 자정에 자동 삭제하는 로직 추가